### PR TITLE
New witness scheduling algorithm

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -904,10 +904,10 @@ void database::update_witness_schedule4() {
    const auto& pow_idx      = get_index_type<witness_index>().indices().get<by_pow>();
    auto mitr = pow_idx.upper_bound(0);
    while( mitr != pow_idx.end() && selected_miners.size() < STEEMIT_MAX_MINER_WITNESSES ) {
-      if( selected_voted.find(mitr->get_id()) != selected_voted.end() )
-         continue; /// Skip miners who are top voted witnesses
-      selected_miners.insert(mitr->get_id());
-      active_witnesses.push_back(mitr->owner);
+      if( selected_voted.find(mitr->get_id()) == selected_voted.end() ) { // Skip any miner who is a  top voted witness
+         selected_miners.insert(mitr->get_id());
+         active_witnesses.push_back(mitr->owner);
+      }
       auto itr = mitr;
       ++mitr;
       modify( *itr, [&](witness_object& wit ) {

--- a/libraries/chain/include/steemit/chain/config.hpp
+++ b/libraries/chain/include/steemit/chain/config.hpp
@@ -56,7 +56,10 @@
 #define STEEMIT_INIT_MINER_NAME                 "initminer"
 #define STEEMIT_NUM_INIT_MINERS                 1
 #define STEEMIT_INIT_TIME                       (fc::time_point_sec());
-#define STEEMIT_MAX_MINERS                      21 /// 21 is more than enough
+#define STEEMIT_MAX_VOTED_WITNESSES             19
+#define STEEMIT_MAX_MINER_WITNESSES             1
+#define STEEMIT_MAX_RUNNER_WITNESSES            1
+#define STEEMIT_MAX_MINERS                      (STEEMIT_MAX_VOTED_WITNESSES+STEEMIT_MAX_MINER_WITNESSES+STEEMIT_MAX_RUNNER_WITNESSES) /// 21 is more than enough
 #define STEEMIT_MAX_TIME_UNTIL_EXPIRATION       (60*60) // seconds,  aka: 1 hour
 #define STEEMIT_MAX_MEMO_SIZE                   2048
 #define STEEMIT_MAX_PROXY_RECURSION_DEPTH       4


### PR DESCRIPTION
This is another implementation of the witness scheduling algorithm that solves the runner-up witness bug as an alternative to the one currently in develop. I have partially tested it and it seems to be working really well.

I think this implementation is more fair than the one currently in develop because it completely ignores the top 19 witnesses when considering who to choose for the runner-up race. Here is a sample of the sequence of runner-up witnesses chosen each round in my simulated tests (based on voting state as of earlier today, April 28, 2016):
```
cyrano.witness
xeldal
silversteem
bue
joseph
delegate.lafona
riverhead
masteryoda
boatymcboatface
ihashfury
salvation
cyrano.witness
xeldal
pumpkin
silversteem
bitcube
blocktrades
bue
modprobe
testzcrypto
```

I believe the other implementation in develop will unfairly favor the runner-up witness in rank 20.
