### PR TITLE
Update LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,24 +1,43 @@
-Copyright (c) 2016 Steemit, Inc., and contributors.
+Except as noted below, Steem is provided under the following license:
 
-The following license applies to code contained within this repository that
-is created by Steemit, Inc. Other copy right holders have licensed dependencis such
-as Graphene, FC, and Boost under their own individual licenses. 
+    Copyright (c) 2016 Steemit, Inc., and contributors.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+    The following license applies to code contained within this repository that is created by Steemit, Inc.
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-3. The currency symbols, 'STEEM' and 'SBD' are not changed and no new currency symbols are added.
-4. The STEEMIT_INIT_PUBLIC_KEY_STR is not changed from STM8GC13uCZbP44HzMLV6zPZGwVQ8Nt4Kji8PapsPiNq1BK153XTX,
-and the software is not modified in any way that would bypass the need for the coresponding private to start
-a new blockchain.
-5. The software is not used with any forks of the Steem blockchain that are not recognized by Steemit, Inc in writing.
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided
+    that the following conditions are met: 
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+    1. Copyright notice for the Graphene library be included as defined below.
+    2. Redistributions of source code must retain the above copyright notices, this list of conditions and
+       the following disclaimer. 
+    3. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+       the following disclaimer in the documentation and/or other materials provided with the distribution. 
+    4. The currency symbols, 'STEEM' and 'SBD' are not changed and no new currency symbols are added. 
+    5. The STEEMIT_INIT_PUBLIC_KEY_STR is not changed from
+       STM8GC13uCZbP44HzMLV6zPZGwVQ8Nt4Kji8PapsPiNq1BK153XTX, and the software is not modified in any way
+       that would bypass the need for the coresponding private to start a new blockchain. 
+    6. The software is not used with any forks of the Steem blockchain that are not recognized by
+       Steemit, Inc. in writing.
+
+The Graphene library is licensed as follows:
+
+    Copyright (c) 2015 Cryptonomex, Inc., and contributors.
+
+    The MIT License 
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+    associated documentation files (the "Software"), to deal in the Software without restriction, 
+    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do
+    so,subject to the following conditions: 
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial
+    portions of the Software. 
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+    OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+    OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 


### PR DESCRIPTION
Update LICENSE.md to meet Graphene library copyright requirement to include the MIT license within derived works. 