### PR TITLE
Fix out-of-source builds

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -1,7 +1,7 @@
 file(GLOB HEADERS "include/steemit/chain/*.hpp")
 
 add_custom_target( build_hardfork_hpp
-                   COMMAND cat-parts hardfork.d "${CMAKE_CURRENT_BINARY_DIR}/include/steemit/chain/hardfork.hpp" )
+   COMMAND cat-parts "${CMAKE_CURRENT_SOURCE_DIR}/hardfork.d" "${CMAKE_CURRENT_BINARY_DIR}/include/steemit/chain/hardfork.hpp" )
 set_source_files_properties( "${CMAKE_CURRENT_BINARY_DIR}/include/steemit/chain/hardfork.hpp" PROPERTIES GENERATED TRUE )
 
 add_dependencies( build_hardfork_hpp cat-parts )

--- a/libraries/wallet/CMakeLists.txt
+++ b/libraries/wallet/CMakeLists.txt
@@ -8,7 +8,8 @@ if( PERL_FOUND AND DOXYGEN_FOUND AND NOT "${CMAKE_GENERATOR}" STREQUAL "Ninja" )
   add_custom_command( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/doxygen/perlmod/DoxyDocs.pm
                       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                       COMMAND ${DOXYGEN_EXECUTABLE}
-                      DEPENDS Doxyfile include/steemit/wallet/wallet.hpp )
+                      DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile ${CMAKE_CURRENT_SOURCE_DIR}/include/steemit/wallet/wallet.hpp )
+
   add_custom_command( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/api_documentation.cpp
                       COMMAND ${PERL_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate_api_documentation.pl ${CMAKE_CURRENT_BINARY_DIR}/api_documentation.cpp.new
 

--- a/programs/build_helpers/cat-parts.cpp
+++ b/programs/build_helpers/cat-parts.cpp
@@ -61,9 +61,16 @@ int main( int argc, char** argv, char** envp )
          }
       }
 
+      auto opath_dir = opath.parent_path();
+      boost::filesystem::create_directories(opath_dir);
+
       {
          boost::filesystem::ofstream ofs(opath);
          ofs.write( new_data.c_str(), new_data.length() );
+         if( !ofs.good() ) {
+            std::cerr << "Could not write file " << opath << std::endl;
+            return 1;
+         }
       }
 
       std::cerr << "Built " << opath << " from .d directory" << std::endl;


### PR DESCRIPTION
Building from a directory other than the source directory should now work with these changes.

As @abitmore suggested [here](https://github.com/steemit/steem/pull/51#issuecomment-218393375), I rebased to get rid of the commits that changed unrelated files.