### PR TITLE
Fix error reading compression flag from config.ini

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     endif()
 endif()
 
+
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules" )
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")

--- a/programs/steemd/main.cpp
+++ b/programs/steemd/main.cpp
@@ -284,6 +284,15 @@ fc::optional<fc::logging_config> load_logging_config_from_ini_file(const fc::pat
             file_appender_config.rotate = true;
             file_appender_config.rotation_interval = fc::hours(1);
             file_appender_config.rotation_limit = fc::days(1);
+            try
+            {
+               file_appender_config.rotation_compression = section_tree.get<bool>("compress");
+            }
+            catch (const boost::property_tree::ptree_bad_path& e)
+            {
+               file_appender_config.rotation_compression = false;
+            }
+
             logging_config.appenders.push_back(fc::appender_config(file_appender_name, "file", fc::variant(file_appender_config)));
             found_logging_config = true;
          }


### PR DESCRIPTION
allow logfile gzipping of rotated-out log files to be controlled from config.ini.  

**This requires a change to FC that enables compression: https://github.com/steemit/fc/pull/4**
