### PR TITLE
Remove duplicate code from cashout_comment_helper

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -2000,9 +2000,6 @@ void database::cashout_comment_helper( const comment_object& comment )
 
          fc::uint128_t old_rshares2 = calculate_vshares( comment.net_rshares.value );
          adjust_rshares2( comment, old_rshares2, 0 );
-
-         if( reward_tokens > 0 )
-            push_virtual_operation( comment_reward_operation( comment.author, comment.permlink, total_payout ) );
       }
 
       modify( cat, [&]( category_object& c )


### PR DESCRIPTION
The removed code shouldn't be there because [Line 1980](https://github.com/steemit/steem/blob/7c71d291d43d7e8d52c0c7090f081df6f7b10704/libraries/chain/database.cpp#L1980) has done the job.