### PR TITLE
387 one touch testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,36 +4,19 @@
 *.cmake
 CMakeCache.txt
 CMakeFiles
-Makefile
 compile_commands.json
 moc_*
 *.moc
 hardfork.hpp
 
+build/
 lcov
 
 libraries/utilities/git_revision.cpp
-
 libraries/wallet/Doxyfile
 libraries/wallet/api_documentation.cpp
 libraries/wallet/doxygen
 
-programs/cli_wallet/cli_wallet
-programs/js_operation_serializer/js_operation_serializer
-programs/steemd/steemd
-programs/steemd/test
-programs/delayed_node
-programs/build_helpers/cat-parts
-programs/size_checker/size_checker
-programs/util/get_dev_key
-programs/util/inflation_model
-
-tests/app_test
-tests/chain_bench
-tests/chain_test
-tests/plugin_test
-tests/intense_test
-tests/performance_test
 
 doxygen
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,91 @@
+# Double build systems, you say?
+# Consider this the documentation file that contains the authoritative
+# instructions for testing, via cmake (the primary build system).
+
+UNAME := $(shell uname)
+
+CMAKE_OPTS :=
+
+# set MAKEOPTS with correct number of cpu threads on linux
+ifeq ($(UNAME), Linux)
+MAKEOPTS := -j$(shell nproc)
+endif
+
+# set MAKEOPTS with correct number of cpu threads on osx/darwin
+ifeq ($(UNAME), Darwin)
+MAKEOPTS := -j$(shell sysctl machdep.cpu.thread_count | awk '{print $$2}')
+endif
+
+.PHONY: docker build test install submodule_init clean
+
+default: defaultbuild
+
+submodule_init:
+	git submodule update --init --recursive
+
+docker_build_container:
+	docker build \
+		--rm=false \
+		-t steemitinc/ci-test-environment:latest \
+		-f tests/scripts/Dockerfile.testenv \
+		.
+
+# docker_build_container is not a prereq here on this target in the file
+# (even though it is an actual prerequisite) because on circleci it caches
+# that via the setup script called from circle.yml so it may already exist
+# on the CI box now without explicitly building it. if it doesn't, it will
+# call the docker_build_container rule above to create it.
+dockertest:
+	docker build \
+		--rm=false \
+		-t steemitinc/steem-test:latest \
+		-f ./Dockerfile.test \
+		.
+
+dockerimage:
+	docker build \
+		--rm=false \
+		-t steemitinc/steem:latest \
+		.
+
+build/Makefile: submodule_init
+	mkdir build && cd build && cmake $(CMAKE_OPTS) ..
+
+# default, vanilla build
+defaultbuild: CMAKE_OPTS += -DLOW_MEMORY_NODE=ON
+defaultbuild: CMAKE_OPTS += -DENABLE_CONTENT_PATCHING=OFF
+defaultbuild: CMAKE_OPTS += -DCLEAR_VOTES=ON
+defaultbuild: CMAKE_OPTS += -DCMAKE_BUILD_TYPE=Release
+defaultbuild: build/Makefile
+	cd build && make $(MAKEOPTS)
+
+# web-frontend supporting build
+webbuild: CMAKE_OPTS += -DLOW_MEMORY_NODE=OFF
+webbuild: CMAKE_OPTS += -DENABLE_CONTENT_PATCHING=ON
+webbuild: CMAKE_OPTS += -DCLEAR_VOTES=OFF
+webbuild: CMAKE_OPTS += -DCMAKE_BUILD_TYPE=Release
+webbuild: build/Makefile
+	cd build && make $(MAKEOPTS)
+
+# testing build
+testbuild: CMAKE_OPTS += -DLOW_MEMORY_NODE=OFF
+testbuild: CMAKE_OPTS += -DENABLE_CONTENT_PATCHING=ON
+testbuild: CMAKE_OPTS += -DBUILD_STEEM_TESTNET=On
+testbuild: CMAKE_OPTS += -DCMAKE_BUILD_TYPE=Debug
+testbuild: build/Makefile
+	cd build && make $(MAKEOPTS) chain_test
+
+test: testbuild
+	cd build && ./tests/chain_test
+
+# one-touch testing on osx with virtualbox/docker-machine/docker
+# attempts to mirror CircleCI setup in /circle.yml as closely as possible
+osxtest:
+	bash tests/scripts/osx-run-tests.sh
+
+install: build
+	cd build && make install
+
+# remove build directory
+clean:
+	rm -rf build

--- a/circle.yml
+++ b/circle.yml
@@ -11,4 +11,4 @@ dependencies:
 
 test:
     override:
-        - time docker build --rm=false -t steemitinc/steem-test -f Dockerfile.test .
+        - make dockertest

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -1,64 +1,83 @@
-Steem OS X Build Instructions
-===============================
+# Steem OS X Build Instructions
 
-1. Install XCode and its command line tools by following the instructions here: https://guide.macports.org/#installing.xcode.
-   In OS X 10.11 (El Capitan) and newer, you will be prompted to install developer tools when running a devloper command in the terminal. This step may not be needed.
+## Prerequisites
 
-
-2. Install Homebrew by following the instructions here: http://brew.sh/
-
-3. Initialize Homebrew:
-   ```
-   brew doctor
-   brew update
-   brew tap homebrew/versions
-   ```
-
-4. Install dependencies:
-   ```
-   brew install homebrew/versions/boost160 cmake git openssl autoconf automake libtool python3
-   ```
-   Note: brew recently updated to boost 1.61.0, which is not yet supported by Steem. Until then, this will allow you to
-   install boost 1.60.0.
+Install XCode and its command line tools by following the instructions
+here: https://guide.macports.org/#installing.xcode.  In OS X 10.11 (El
+Capitan) and newer, you will be prompted to install developer tools when
+running a devloper command in the terminal. The manual installation of XCode
+on 10.11 and later may thus not be required.
 
 
-5. *Optional.* To use TCMalloc in LevelDB:
-   ```
-   brew install google-perftools
-   ```
+## Install Homebrew
 
-6. Clone the Steem repository:
-   ```
-   git clone https://github.com/steemit/steem.git
-   cd steem
-   ```
+Install the Homebrew package manager by following the instructions here:
 
-7. Build Steem:
-   ```
-   export OPENSSL_ROOT_DIR=/usr/local/Cellar/openssl/1.0.2h_1/
-   export BOOST_ROOT=/usr/local/Cellar/boost160/1.60.0/
-   git submodule update --init --recursive
-   cmake -DBOOST_ROOT="$BOOST_ROOT" -DCMAKE_BUILD_TYPE=Release .
-   make
-   ```
+* http://brew.sh/
 
-   Note, if you have multiple cores and you would like to compile faster, you can append `-j <number of threads>` to `make` e.g.:
-   ```
-   make -j4
-   ```
+## Initialize Homebrew:
 
-   Also, some useful build targets for `make` are:
-   ```
-   steemd
-   chain_test
-   cli_wallet
-   ```
+```
+brew doctor
+brew update
+brew tap homebrew/versions
+```
 
-   e.g.:
-   ```
-   make steemd
-   ```
-   This will only build steemd
+## Install Dependencies:
 
-8. cmake Build Options:
-   See README.md for a detailed description of available cmake options
+```
+brew install homebrew/versions/boost160 cmake git openssl autoconf automake libtool python3
+```
+
+Note: brew recently updated to boost 1.61.0, which is not yet supported
+by Steem. Until then, this will allow you to install boost 1.60.0.
+
+
+## (Optional) To use TCMalloc in LevelDB
+
+```
+brew install google-perftools
+```
+
+## Clone the Steem repository
+
+```
+git clone https://github.com/steemit/steem.git
+cd steem
+```
+
+## Build Steem
+
+```
+export OPENSSL_ROOT_DIR=/usr/local/Cellar/openssl/1.0.2h_1/
+export BOOST_ROOT=/usr/local/Cellar/boost160/1.60.0/
+git submodule update --init --recursive
+mkdir build && cd build
+cmake -DBOOST_ROOT="$BOOST_ROOT" -DCMAKE_BUILD_TYPE=Release ..
+make -j$(sysctl machdep.cpu.thread_count | awk '{print $2}')
+```
+
+Also, some useful build targets for `make` are:
+
+```
+steemd
+chain_test
+cli_wallet
+```
+
+e.g.:
+
+```
+make steemd
+```
+
+(This will only build steemd.)
+
+## cmake Build Options:
+
+See [/README.md](../README.md) for a detailed description of available cmake options.
+
+## See Also
+
+- LTS Ubuntu Linux build instructions are found in [doc/build-ubuntu.md](build-ubuntu.md).
+- Windows build instructions do not yet exist.

--- a/doc/build-ubuntu.md
+++ b/doc/build-ubuntu.md
@@ -1,65 +1,153 @@
-### Ubuntu 16.04
+# LTS Ubuntu Linux Build Instructions
 
-For Ubuntu 16.04 users, after installing the right packages with `apt` Steem will build out of the box without further effort:
+## Ubuntu 16.04 Xenial
 
-    # Required packages
-    sudo apt-get install git make automake cmake g++ libssl-dev autoconf libtool
+For Ubuntu 16.04 users, after installing the right packages with `apt` Steem
+will build out of the box without further effort:
 
-    # Boost packages (also required)
-    sudo apt-get install libboost-thread-dev libboost-date-time-dev libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-signals-dev libboost-serialization-dev libboost-chrono-dev libboost-test-dev libboost-context-dev libboost-locale-dev libboost-coroutine-dev libboost-iostreams-dev
+### Install Build Prerequisites
 
-    # Optional packages (not required, but will make a nicer experience)
-    sudo apt-get install doxygen perl libreadline-dev libncurses5-dev
+```
+# Required packages for build
+sudo apt-get install -y \
+    autoconf \
+    automake \
+    cmake \
+    g++ \
+    git \
+    libssl-dev \
+    libtool \
+    make
+```
 
-    git clone https://github.com/steemit/steem
-    cd steem
-    git submodule update --init --recursive
-    cmake -DCMAKE_BUILD_TYPE=Release .
-    make steemd
-    make cli_wallet
+```
+# Boost packages (also required for build)
+sudo apt-get install -y \
+    libboost-chrono-dev \
+    libboost-context-dev \
+    libboost-coroutine-dev \
+    libboost-date-time-dev \
+    libboost-filesystem-dev \
+    libboost-iostreams-dev \
+    libboost-locale-dev \
+    libboost-program-options-dev \
+    libboost-serialization-dev \
+    libboost-signals-dev \
+    libboost-system-dev \
+    libboost-test-dev \
+    libboost-thread-dev
+```
 
-You can add the `-j` parameter to the `make` command to compile in parallel on a machine with lots of memory and multiple cores (e.g. `make -j4 steemd`).
+```
+# Optional packages
+# (not required, but will make a nicer experience)
+sudo apt-get install -y \
+    doxygen \
+    libncurses5-dev \
+    libreadline-dev \
+    perl
 
-### Ubuntu 14.04
+```
 
-Here are the required packages:
+### Building
 
-    # Required packages
-    sudo apt-get install git make cmake g++ libssl-dev autoconf libtool
+```
+git clone https://github.com/steemit/steem
+cd steem
+git submodule update --init --recursive
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j$(nproc) # builds all targets
+sudo make install # optional
+```
 
-    # Packages required to build Boost
-    sudo apt-get install python-dev libbz2-dev
+### Other Make Targets
 
-    # Optional packages (not required, but will make a nicer experience)
-    sudo apt-get install doxygen perl libreadline-dev libncurses5-dev
+```
+make -j$(nproc) steemd      # build only steemd
+make -j$(nproc) cli_wallet  # build just cli_wallet
+```
 
-Steem requires Boost 1.57 or later. The Boost provided in the Ubuntu 14.04 package manager (Boost 1.55) is too old. So building Steem on Ubuntu 14.04 requires downloading and installing a more recent version of Boost.
+## Ubuntu 14.04 Trusty
 
-According to [this mailing list post](http://boost.2283326.n4.nabble.com/1-58-1-bugfix-release-necessary-td4674686.html), Boost 1.58 is not compatible with gcc 4.8 (the default C++ compiler for Ubuntu 16.04) when compiling in C++11 mode (which Steem does). So we will use Boost 1.57; if you try to build with any other version, you will probably have a bad time.
+### Install Build Prerequisites
 
-Here is how to build and install Boost 1.57 into your user's home directory (make sure you install all the packages above first):
+```
+# Required packages
+sudo apt-get install -y \
+    autoconf \
+    cmake \
+    g++ \
+    git \
+    libssl-dev \
+    libtool \
+    make
+```
 
-    BOOST_ROOT=$HOME/opt/boost_1_57_0
-    wget -c 'http://sourceforge.net/projects/boost/files/boost/1.57.0/boost_1_57_0.tar.bz2/download' -O boost_1_57_0.tar.bz2
-    [ $( sha256sum boost_1_57_0.tar.bz2 | cut -d ' ' -f 1 ) == "910c8c022a33ccec7f088bd65d4f14b466588dda94ba2124e78b8c57db264967" ] || ( echo 'Corrupt download' ; exit 1 )
-    tar xjf boost_1_57_0.tar.bz2
-    cd boost_1_57_0
-    ./bootstrap.sh "--prefix=$BOOST_ROOT"
-    ./b2 install
+```
+# Packages required to build Boost
+sudo apt-get install -y \
+    libbz2-dev \
+    python-dev
+```
 
-Then the instructions are the same as for Steem:
+```
+# Optional packages (not required, but will make a nicer experience)
+sudo apt-get install -y \
+    doxygen \
+    libncurses5-dev \
+    libreadline-dev \
+    perl
+```
 
-    git clone https://github.com/steemit/steem
-    cd steem
-    git submodule update --init --recursive
-    cmake -DCMAKE_BUILD_TYPE=Release .
-    make steemd
-    make cli_wallet
+### Boost Version
+
+Steem requires Boost 1.57 or later. The Boost provided in the Ubuntu 14.04
+package manager (Boost 1.55) is too old. So building Steem on Ubuntu 14.04
+requires downloading and installing a more recent version of Boost.
+
+According to [this mailing list
+post](http://boost.2283326.n4.nabble.com/1-58-1-bugfix-release-necessary-td4674686.html),
+Boost 1.58 is not compatible with gcc 4.8 (the default C++ compiler for
+that Ubuntu) when compiling in C++11 mode (which Steem does). So we will
+use Boost 1.57; if you try to build with any other version, you will
+probably have a bad time.
+
+Here is how to build and install Boost 1.57 into your user's home directory
+(make sure you install all the packages above first):
+
+```
+BOOST_ROOT=$HOME/opt/boost_1_57_0
+wget -c 'http://sourceforge.net/projects/boost/files/boost/1.57.0/boost_1_57_0.tar.bz2/download' -O boost_1_57_0.tar.bz2
+[ $( sha256sum boost_1_57_0.tar.bz2 | cut -d ' ' -f 1 ) == "910c8c022a33ccec7f088bd65d4f14b466588dda94ba2124e78b8c57db264967" ] || ( echo 'Corrupt download' ; exit 1 )
+tar xjf boost_1_57_0.tar.bz2
+cd boost_1_57_0
+./bootstrap.sh "--prefix=$BOOST_ROOT"
+./b2 install
+```
+
+### Building
+
+```
+git clone https://github.com/steemit/steem
+cd steem
+git submodule update --init --recursive
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j$(nproc)
+sudo make install # optional
+```
 
 ### Other setups
 
-- OSX (Apple) build instructions are [here](BUILD_OSX.md).
+- OSX (Apple) build instructions are found in
+  [doc/build-osx.md](build-osx.md).
 - Windows build instructions do not yet exist.
 
-- The developers normally compile with gcc and clang. These compilers should be well-supported.
-- Community members occasionally attempt to compile the code with mingw, Intel and Microsoft compilers. These compilers may work, but the developers do not use them. Pull requests fixing warnings / errors from these compilers are accepted.
+- The developers normally compile with gcc and clang. These compilers should
+  be well-supported. If you run into issues with these, please file an issue
+  at [the GitHub issue tracker](https://github.com/steemit/steem/issues).
+- Community members occasionally attempt to compile the code with mingw,
+  Intel and Microsoft compilers. These compilers may work, but the
+  developers do not use them. Pull requests fixing warnings / errors from
+  these compilers are accepted.

--- a/tests/scripts/create-ci-docker-image.sh
+++ b/tests/scripts/create-ci-docker-image.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -x
 
+# exit if we're not running on circleci:
+if [[ -z "$CIRCLE_BUILD_NUM" ]]; then
+    echo "This is to be run on CircleCI only." > /dev/stderr
+    exit 1
+fi
+
 DOCKER_CACHE_DIR="$HOME/docker"
 
 if [[ ! -d $DOCKER_CACHE_DIR ]]; then
@@ -11,9 +17,7 @@ if [[ -e $DOCKER_CACHE_DIR/image.tar ]]; then
     du -sh $DOCKER_CACHE_DIR/image.tar
     docker load -i $DOCKER_CACHE_DIR/image.tar
 else
-    docker build --rm=false \
-        -t steemitinc/ci-test-environment:latest \
-        -f tests/scripts/Dockerfile.testenv . && \
+    make docker_build_container && \
     mkdir -p ~/docker && \
     docker save steemitinc/ci-test-environment:latest \
         > $DOCKER_CACHE_DIR/image.tar.tmp && \

--- a/tests/scripts/osx-run-tests.sh
+++ b/tests/scripts/osx-run-tests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -x
+
+PKGS="docker docker-machine"
+
+# install packages with homebrew if they don't exist
+for PKG in $PKGS ; do
+    if ! which $PKG 2>&1 >/dev/null ; then
+        brew install $PKG
+    fi
+done
+
+
+if ! docker ps 2>&1 >/dev/null ; then
+    TOTAL_MEMORY_BYTES=$(sysctl hw.memsize | awk '{print $2}')
+    TOTAL_MEMORY_MEGS=$(( $TOTAL_MEMORY_BYTES / 1048576 ))
+    HALF_MEMORY_MEGS=$(( $TOTAL_MEMORY_MEGS / 2 ))
+
+    MACHINE_NAME=steemtest
+    CREATED=1
+    docker-machine create \
+        --driver virtualbox \
+        --virtualbox-no-share \
+        --virtualbox-cpu-count "-1" \
+        --virtualbox-memory $HALF_MEMORY_MEGS \
+        $MACHINE_NAME
+
+    eval $(docker-machine env $MACHINE_NAME)
+fi
+
+make docker
+
+if [[ $CREATED -eq 1 ]]; then
+    docker-machine rm -f $MACHINE_NAME
+fi


### PR DESCRIPTION
This change should be discussed before merge - it removes the top-level Makefile and the build products from the `.gitignore` and expects `cmake` and `make` to be run from an ephemeral `build` subdirectory.

Requesting feedback @steemit/steem-developers - would this be a major inconvenience?

It significantly simplifies building/testing scripts and processes, as well as the `.gitignore`.