### PR TITLE
Error message adjusted to value of STEEMIT_OWNER_UPDATE_LIMIT

### DIFF
--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -155,7 +155,7 @@ void account_update_evaluator::do_apply( const account_update_operation& o )
    {
 #ifndef IS_TESTNET
       if( db().has_hardfork( STEEMIT_HARDFORK_0_11 ) )
-         FC_ASSERT( db().head_block_time() - account.last_owner_update > STEEMIT_OWNER_UPDATE_LIMIT, "can only update owner authority once a minute" );
+         FC_ASSERT( db().head_block_time() - account.last_owner_update > STEEMIT_OWNER_UPDATE_LIMIT, "can only update owner authority once an hour" );
 #endif
 
       db().update_owner_authority( account, *o.owner );


### PR DESCRIPTION
`STEEMIT_OWNER_UPDATE_LIMIT` is currently set to `fc::minutes(60)`:
https://github.com/steemit/steem/blob/develop/libraries/chain/include/steemit/chain/config.hpp#L62

Error message should reflect that.
