### PR TITLE
does not run tests as part of main docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,29 +30,6 @@ ADD . /usr/local/src/steem
 RUN \
     cd /usr/local/src/steem && \
     git submodule update --init --recursive && \
-    rsync -a \
-        /usr/local/src/steem/ \
-        /usr/local/src/steemtest/
-
-RUN \
-    cd /usr/local/src/steemtest && \
-    cmake \
-        -DCMAKE_BUILD_TYPE=Debug \
-        -DBUILD_STEEM_TESTNET=On \
-        -DLOW_MEMORY_NODE=ON \
-        . \
-    && \
-    make -j$(nproc) chain_test && \
-    ./tests/chain_test && \
-    rm -rf /usr/local/src/steemtest
-
-RUN \
-    cd /usr/local/src/steem && \
-    doxygen && \
-    programs/build_helpers/check_reflect.py
-
-RUN \
-    cd /usr/local/src/steem && \
     mkdir build && \
     cd build && \
     cmake \


### PR DESCRIPTION
Now that the `Dockerfile` is building both a web node and a p2p node type, the builds on Docker Hub are timing out. This removes the full test build/run in the Dockerfile (which was only there as a sort of belt-and-suspenders approach, as we do the exact same tests before merging to `develop` or `master` anyway).