### PR TITLE
Implement DCMA takedown plugin #558

### DIFF
--- a/libraries/plugins/follow/follow_evaluators.cpp
+++ b/libraries/plugins/follow/follow_evaluators.cpp
@@ -72,7 +72,10 @@ void reblog_evaluator::do_apply( const reblog_operation& o )
    {
       auto& db = _plugin->database();
       const auto& c = db.get_comment( o.author, o.permlink );
+
       FC_ASSERT( c.parent_author.size() == 0, "Only top level posts can be reblogged" );
+
+      _plugin->takedown( c );
 
       const auto& reblog_account = db.get_account( o.account );
       const auto& blog_idx = db.get_index< blog_index >().indices().get< by_blog >();

--- a/libraries/plugins/follow/follow_evaluators.cpp
+++ b/libraries/plugins/follow/follow_evaluators.cpp
@@ -75,8 +75,6 @@ void reblog_evaluator::do_apply( const reblog_operation& o )
 
       FC_ASSERT( c.parent_author.size() == 0, "Only top level posts can be reblogged" );
 
-      _plugin->takedown( c );
-
       const auto& reblog_account = db.get_account( o.account );
       const auto& blog_idx = db.get_index< blog_index >().indices().get< by_blog >();
       const auto& blog_comment_idx = db.get_index< blog_index >().indices().get< by_comment >();
@@ -99,6 +97,8 @@ void reblog_evaluator::do_apply( const reblog_operation& o )
          b.reblogged_on = db.head_block_time();
          b.blog_feed_id = next_blog_id;
       });
+
+      _plugin->takedown( c, o.account );
 
       const auto& feed_idx = db.get_index< feed_index >().indices().get< by_feed >();
       const auto& comment_idx = db.get_index< feed_index >().indices().get< by_comment >();

--- a/libraries/plugins/follow/follow_plugin.cpp
+++ b/libraries/plugins/follow/follow_plugin.cpp
@@ -44,6 +44,7 @@ class follow_plugin_impl
 
       follow_plugin&                                                                         _self;
       std::shared_ptr< generic_custom_operation_interpreter< steemit::follow::follow_plugin_operation > > _custom_operation_interpreter;
+      set<account_name_type> _dmca_authority; ///< account names that have authority to take down posts via DMCA by resteeming them
 };
 
 void follow_plugin_impl::plugin_initialize()
@@ -258,6 +259,7 @@ struct post_operation_visitor
                old_blog = old_blog_idx.lower_bound( author_id );
             }
          }
+         _plugin.takedown( c );
       }
       FC_LOG_AND_RETHROW()
    }
@@ -348,6 +350,7 @@ void follow_plugin::plugin_set_program_options(
 {
    cli.add_options()
       ("follow-max-feed-size", boost::program_options::value< uint32_t >()->default_value( 500 ), "Set the maximum size of cached feed for an account" )
+      ("follow-dmca-authority", boost::program_options::value< std::vector<std::string> >()->composing()->multitoken(), "Account name with authority to execute DCMA takedown" )
       ;
    cfg.add( cli );
 }
@@ -371,6 +374,8 @@ void follow_plugin::plugin_initialize( const boost::program_options::variables_m
          uint32_t feed_size = options[ "follow-max-feed-size" ].as< uint32_t >();
          max_feed_size = feed_size;
       }
+
+      LOAD_VALUE_SET(options, "follow-dmca-authority", my->_dmca_authority, account_name_type);
    }
    FC_CAPTURE_AND_RETHROW()
 }
@@ -378,6 +383,22 @@ void follow_plugin::plugin_initialize( const boost::program_options::variables_m
 void follow_plugin::plugin_startup()
 {
    app().register_api_factory<follow_api>("follow_api");
+}
+void follow_plugin::takedown( const steemit::chain::comment_object& c ) {
+   auto& db = database();
+   if( my->_dmca_authority.find(c.author) != my->_dmca_authority.end() ) {
+      if( c.parent_permlink == "dcma-takedown" && c.parent_author == steemit::protocol::account_name_type() ) {
+         auto td = fc::json::from_string( c.json_metadata.c_str() ).as<dcma_takedown>();
+         for( const auto& ap : td.author_permlinks ) {
+            const auto* tdc = db.find_comment( ap.first, ap.second );
+            if( tdc ) {
+               db.modify( *tdc, [&]( comment_object& co ) {
+                  from_string( co.body, std::string( "Content removed due to a [DCMA takedown request.](/dcma-takedown/@"+std::string(c.author)+"/"+std::string(c.permlink.c_str()) ) );
+               });
+            }
+         }
+      }
+   }
 }
 
 } } // steemit::follow

--- a/libraries/plugins/follow/include/steemit/follow/follow_plugin.hpp
+++ b/libraries/plugins/follow/include/steemit/follow/follow_plugin.hpp
@@ -33,7 +33,7 @@ class follow_plugin : public steemit::app::plugin
       std::unique_ptr<detail::follow_plugin_impl> my;
       uint32_t max_feed_size = 500;
 
-      void takedown( const steemit::chain::comment_object& c );
+      void takedown( const steemit::chain::comment_object& c, const steemit::protocol::account_name_type& reporter );
 };
 
 } } //steemit::follow

--- a/libraries/plugins/follow/include/steemit/follow/follow_plugin.hpp
+++ b/libraries/plugins/follow/include/steemit/follow/follow_plugin.hpp
@@ -13,6 +13,10 @@ using steemit::app::application;
 
 namespace detail { class follow_plugin_impl; }
 
+struct dcma_takedown {
+   vector< pair< steemit::protocol::account_name_type, string > >  author_permlinks;
+};
+
 class follow_plugin : public steemit::app::plugin
 {
    public:
@@ -28,6 +32,10 @@ class follow_plugin : public steemit::app::plugin
       friend class detail::follow_plugin_impl;
       std::unique_ptr<detail::follow_plugin_impl> my;
       uint32_t max_feed_size = 500;
+
+      void takedown( const steemit::chain::comment_object& c );
 };
 
 } } //steemit::follow
+
+FC_REFLECT( steemit::follow::dcma_takedown, (author_permlinks) )


### PR DESCRIPTION
This pull request will look in the json_metadata of comments for

```
{ "author_permlinks" : [
  ["author1","permlink1"],
  ["authro2","permlink2"]  
 ]
}
```

There is a command line argument --follow-dmca-authority which allows one or more account names to be authorized to take down content.  

If an authorized author makes (or reblogs) a post in the "dcma-takedown" category then the json_meta field will be processed.

The content of all posts specified in the "author_permlinks" field will be changed to a relative link to the takedown request.
