### PR TITLE
Fix get_followers and get_following API calls in the follow plugin

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -1277,11 +1277,11 @@ vector<discussion> database_api::get_discussions_by_feed( const discussion_query
 
    const auto& c_idx = my->_db.get_index< follow::feed_index >().indices().get< follow::by_comment >();
    const auto& f_idx = my->_db.get_index< follow::feed_index >().indices().get< follow::by_feed >();
-   auto feed_itr = f_idx.lower_bound( account.id );
+   auto feed_itr = f_idx.lower_bound( account.name );
 
    if( start_author.size() || start_permlink.size() )
    {
-      auto start_c = c_idx.find( boost::make_tuple( my->_db.get_comment( start_author, start_permlink ).id, account.id ) );
+      auto start_c = c_idx.find( boost::make_tuple( my->_db.get_comment( start_author, start_permlink ).id, account.name ) );
       FC_ASSERT( start_c != c_idx.end(), "Comment is not in account's feed" );
       feed_itr = f_idx.iterator_to( *start_c );
    }
@@ -1291,14 +1291,14 @@ vector<discussion> database_api::get_discussions_by_feed( const discussion_query
 
    while( result.size() < query.limit && feed_itr != f_idx.end() )
    {
-      if( feed_itr->account != account.id )
+      if( feed_itr->account != account.name )
          break;
       try
       {
          result.push_back( get_discussion( feed_itr->comment ) );
-         if( feed_itr->first_reblogged_by != account_id_type() )
+         if( feed_itr->first_reblogged_by != account_name_type() )
          {
-            result.back().first_reblogged_by = feed_itr->first_reblogged_by( my->_db ).name;
+            result.back().first_reblogged_by = feed_itr->first_reblogged_by;
             result.back().first_reblogged_on = feed_itr->first_reblogged_on;
          }
       }
@@ -1323,11 +1323,11 @@ vector<discussion> database_api::get_discussions_by_blog( const discussion_query
 
    const auto& c_idx = my->_db.get_index< follow::blog_index >().indices().get< follow::by_comment >();
    const auto& b_idx = my->_db.get_index< follow::blog_index >().indices().get< follow::by_blog >();
-   auto blog_itr = b_idx.lower_bound( account.id );
+   auto blog_itr = b_idx.lower_bound( account.name );
 
    if( start_author.size() || start_permlink.size() )
    {
-      auto start_c = c_idx.find( boost::make_tuple( my->_db.get_comment( start_author, start_permlink ).id, account.id ) );
+      auto start_c = c_idx.find( boost::make_tuple( my->_db.get_comment( start_author, start_permlink ).id, account.name ) );
       FC_ASSERT( start_c != c_idx.end(), "Comment is not in account's blog" );
       blog_itr = b_idx.iterator_to( *start_c );
    }
@@ -1337,7 +1337,7 @@ vector<discussion> database_api::get_discussions_by_blog( const discussion_query
 
    while( result.size() < query.limit && blog_itr != b_idx.end() )
    {
-      if( blog_itr->account != account.id )
+      if( blog_itr->account != account.name )
          break;
       try
       {

--- a/libraries/chain/include/steemit/chain/comment_object.hpp
+++ b/libraries/chain/include/steemit/chain/comment_object.hpp
@@ -27,12 +27,7 @@ namespace steemit { namespace chain {
       {
          return less( a.c_str(), b.c_str() );
       }
-      /*
-      bool operator()( const char* a, const char* b )const
-      {
-         return less( a, b );
-      }
-      */
+
       private:
          inline bool less( const char* a, const char* b )const
          {

--- a/libraries/plugins/follow/follow_api.cpp
+++ b/libraries/plugins/follow/follow_api.cpp
@@ -13,8 +13,8 @@ class follow_api_impl
       follow_api_impl( steemit::app::application& _app )
          :app(_app) {}
 
-      vector< follow_object > get_followers( string following, string start_follower, follow_type type, uint16_t limit )const;
-      vector< follow_object > get_following( string follower, string start_following, follow_type type, uint16_t limit )const;
+      vector< follow_api_obj > get_followers( string following, string start_follower, follow_type type, uint16_t limit )const;
+      vector< follow_api_obj > get_following( string follower, string start_following, follow_type type, uint16_t limit )const;
 
       vector< feed_entry > get_feed_entries( string account, uint32_t entry_id, uint16_t limit )const;
       vector< comment_feed_entry > get_feed( string account, uint32_t entry_id, uint16_t limit )const;
@@ -27,10 +27,10 @@ class follow_api_impl
       steemit::app::application& app;
 };
 
-vector< follow_object > follow_api_impl::get_followers( string following, string start_follower, follow_type type, uint16_t limit )const
+vector< follow_api_obj > follow_api_impl::get_followers( string following, string start_follower, follow_type type, uint16_t limit )const
 {
    FC_ASSERT( limit <= 100 );
-   vector<follow_object> result;
+   vector< follow_api_obj > result;
    const auto& idx = app.chain_database()->get_index<follow_index>().indices().get<by_following_follower>();
    const auto& following_obj = app.chain_database()->get_account( following );
    const auto& by_name_idx = app.chain_database()->get_index< account_index >().indices().get< by_name >();
@@ -41,7 +41,11 @@ vector< follow_object > follow_api_impl::get_followers( string following, string
    {
       if( itr->what & ( 1 << type ) )
       {
-         result.push_back( *itr );
+         follow_api_obj entry;
+         entry.follower = itr->follower( *app.chain_database() ).name;
+         entry.following = itr->following( *app.chain_database() ).name;
+         entry.what = type;
+         result.push_back( entry );
          --limit;
       }
 
@@ -51,10 +55,10 @@ vector< follow_object > follow_api_impl::get_followers( string following, string
    return result;
 }
 
-vector< follow_object > follow_api_impl::get_following( string follower, string start_following, follow_type type, uint16_t limit )const
+vector< follow_api_obj > follow_api_impl::get_following( string follower, string start_following, follow_type type, uint16_t limit )const
 {
    FC_ASSERT( limit <= 100 );
-   vector<follow_object> result;
+   vector< follow_api_obj > result;
    const auto& idx = app.chain_database()->get_index<follow_index>().indices().get<by_follower_following>();
    const auto& follower_obj = app.chain_database()->get_account( follower );
    const auto& by_name_idx = app.chain_database()->get_index< account_index >().indices().get< by_name >();
@@ -65,7 +69,11 @@ vector< follow_object > follow_api_impl::get_following( string follower, string 
    {
       if( itr->what & ( 1 << type ) )
       {
-         result.push_back( *itr );
+         follow_api_obj entry;
+         entry.follower = itr->follower( *app.chain_database() ).name;
+         entry.following = itr->following( *app.chain_database() ).name;
+         entry.what = type;
+         result.push_back( entry );
          --limit;
       }
 
@@ -246,12 +254,12 @@ follow_api::follow_api( const steemit::app::api_context& ctx )
 
 void follow_api::on_api_startup() {}
 
-vector<follow_object> follow_api::get_followers( string following, string start_follower, follow_type type, uint16_t limit )const
+vector<follow_api_obj> follow_api::get_followers( string following, string start_follower, follow_type type, uint16_t limit )const
 {
    return my->get_followers( following, start_follower, type, limit );
 }
 
-vector<follow_object> follow_api::get_following( string follower, string start_following, follow_type type, uint16_t limit )const
+vector<follow_api_obj> follow_api::get_following( string follower, string start_following, follow_type type, uint16_t limit )const
 {
    return my->get_following( follower, start_following, type, limit );
 }

--- a/libraries/plugins/follow/follow_api.cpp
+++ b/libraries/plugins/follow/follow_api.cpp
@@ -33,8 +33,10 @@ vector< follow_object > follow_api_impl::get_followers( string following, string
    vector<follow_object> result;
    const auto& idx = app.chain_database()->get_index<follow_index>().indices().get<by_following_follower>();
    const auto& following_obj = app.chain_database()->get_account( following );
-   const auto& start_follower_obj = app.chain_database()->get_account( start_follower );
-   auto itr = idx.lower_bound( std::make_tuple( following_obj.id, start_follower_obj.id ) );
+   const auto& by_name_idx = app.chain_database()->get_index< account_index >().indices().get< by_name >();
+   const auto& start_follower_obj = by_name_idx.lower_bound( start_follower );
+   FC_ASSERT( start_follower_obj != by_name_idx.end(), "start_follower ${s} does not allow for a valid range of accounts.", ("s", start_follower) );
+   auto itr = idx.lower_bound( std::make_tuple( following_obj.id, start_follower_obj->id ) );
    while( itr != idx.end() && limit && itr->following == following_obj.id )
    {
       if( itr->what & ( 1 << type ) )
@@ -55,8 +57,10 @@ vector< follow_object > follow_api_impl::get_following( string follower, string 
    vector<follow_object> result;
    const auto& idx = app.chain_database()->get_index<follow_index>().indices().get<by_follower_following>();
    const auto& follower_obj = app.chain_database()->get_account( follower );
-   const auto& start_following_obj = app.chain_database()->get_account( start_following );
-   auto itr = idx.lower_bound( std::make_tuple( follower_obj.id, start_following_obj.id ) );
+   const auto& by_name_idx = app.chain_database()->get_index< account_index >().indices().get< by_name >();
+   const auto& start_following_obj = by_name_idx.lower_bound( start_following );
+   FC_ASSERT( start_following_obj != by_name_idx.end(), "start_following ${s} does not allow for a valid range of accounts.", ("s", start_following) );
+   auto itr = idx.lower_bound( std::make_tuple( follower_obj.id, start_following_obj->id ) );
    while( itr != idx.end() && limit && itr->follower == follower_obj.id )
    {
       if( itr->what & ( 1 << type ) )

--- a/libraries/plugins/follow/include/steemit/follow/follow_api.hpp
+++ b/libraries/plugins/follow/include/steemit/follow/follow_api.hpp
@@ -53,6 +53,13 @@ struct account_reputation
    share_type  reputation;
 };
 
+struct follow_api_obj
+{
+   string      follower;
+   string      following;
+   follow_type what;
+};
+
 namespace detail
 {
    class follow_api_impl;
@@ -65,8 +72,8 @@ class follow_api
 
       void on_api_startup();
 
-      vector< follow_object > get_followers( string to, string start, follow_type type, uint16_t limit )const;
-      vector< follow_object > get_following( string from, string start, follow_type type, uint16_t limit )const;
+      vector< follow_api_obj > get_followers( string to, string start, follow_type type, uint16_t limit )const;
+      vector< follow_api_obj > get_following( string from, string start, follow_type type, uint16_t limit )const;
 
       vector< feed_entry > get_feed_entries( string account, uint32_t entry_id = 0, uint16_t limit = 500 )const;
       vector< comment_feed_entry > get_feed( string account, uint32_t entry_id = 0, uint16_t limit = 500 )const;
@@ -87,6 +94,7 @@ FC_REFLECT( steemit::follow::comment_feed_entry, (comment)(reblog_by)(reblog_on)
 FC_REFLECT( steemit::follow::blog_entry, (author)(permlink)(blog)(reblog_on)(entry_id) );
 FC_REFLECT( steemit::follow::comment_blog_entry, (comment)(blog)(reblog_on)(entry_id) );
 FC_REFLECT( steemit::follow::account_reputation, (account)(reputation) );
+FC_REFLECT( steemit::follow::follow_api_obj, (follower)(following)(what) );
 
 FC_API( steemit::follow::follow_api,
    (get_followers)

--- a/libraries/plugins/follow/include/steemit/follow/follow_objects.hpp
+++ b/libraries/plugins/follow/include/steemit/follow/follow_objects.hpp
@@ -41,8 +41,8 @@ class follow_object : public object< follow_object_type, follow_object >
 
       id_type           id;
 
-      account_id_type   follower;
-      account_id_type   following;
+      account_name_type follower;
+      account_name_type following;
       uint16_t          what = 0;
 };
 
@@ -62,8 +62,8 @@ class feed_object : public object< feed_object_type, feed_object >
 
       id_type           id;
 
-      account_id_type   account;
-      account_id_type   first_reblogged_by;
+      account_name_type account;
+      account_name_type first_reblogged_by;
       time_point_sec    first_reblogged_on;
       comment_id_type   comment;
       uint32_t          reblogs;
@@ -86,7 +86,7 @@ class blog_object : public object< blog_object_type, blog_object >
 
       id_type           id;
 
-      account_id_type   account;
+      account_name_type account;
       comment_id_type   comment;
       time_point_sec    reblogged_on;
       uint32_t          blog_feed_id = 0;
@@ -108,7 +108,7 @@ class reputation_object : public object< reputation_object_type, reputation_obje
 
       id_type           id;
 
-      account_id_type   account;
+      account_name_type account;
       share_type        reputation;
 };
 
@@ -126,15 +126,17 @@ typedef multi_index_container<
       ordered_unique< tag< by_id >, member< follow_object, follow_id_type, &follow_object::id > >,
       ordered_unique< tag< by_following_follower >,
          composite_key< follow_object,
-            member< follow_object, account_id_type, &follow_object::following >,
-            member< follow_object, account_id_type, &follow_object::follower >
-         >
+            member< follow_object, account_name_type, &follow_object::following >,
+            member< follow_object, account_name_type, &follow_object::follower >
+         >,
+         composite_key_compare< std::less< account_name_type >, std::less< account_name_type > >
       >,
       ordered_unique< tag< by_follower_following >,
          composite_key< follow_object,
-            member< follow_object, account_id_type, &follow_object::follower >,
-            member< follow_object, account_id_type, &follow_object::following >
-         >
+            member< follow_object, account_name_type, &follow_object::follower >,
+            member< follow_object, account_name_type, &follow_object::following >
+         >,
+         composite_key_compare< std::less< account_name_type >, std::less< account_name_type > >
       >
    >,
    allocator< follow_object >
@@ -151,29 +153,31 @@ typedef multi_index_container<
       ordered_unique< tag< by_id >, member< feed_object, feed_id_type, &feed_object::id > >,
       ordered_unique< tag< by_feed >,
          composite_key< feed_object,
-            member< feed_object, account_id_type, &feed_object::account >,
+            member< feed_object, account_name_type, &feed_object::account >,
             member< feed_object, uint32_t, &feed_object::account_feed_id >
          >,
-         composite_key_compare< std::less< account_id_type >, std::greater< uint32_t > >
+         composite_key_compare< std::less< account_name_type >, std::greater< uint32_t > >
       >,
       ordered_unique< tag< by_old_feed >,
          composite_key< feed_object,
-            member< feed_object, account_id_type, &feed_object::account >,
+            member< feed_object, account_name_type, &feed_object::account >,
             member< feed_object, uint32_t, &feed_object::account_feed_id >
          >,
-         composite_key_compare< std::less< account_id_type >, std::less< uint32_t > >
+         composite_key_compare< std::less< account_name_type >, std::less< uint32_t > >
       >,
       ordered_unique< tag< by_account >,
          composite_key< feed_object,
-            member< feed_object, account_id_type, &feed_object::account >,
+            member< feed_object, account_name_type, &feed_object::account >,
             member< feed_object, feed_id_type, &feed_object::id >
-         >
+         >,
+         composite_key_compare< std::less< account_name_type >, std::less< feed_id_type > >
       >,
       ordered_unique< tag< by_comment >,
          composite_key< feed_object,
             member< feed_object, comment_id_type, &feed_object::comment >,
-            member< feed_object, account_id_type, &feed_object::account >
-         >
+            member< feed_object, account_name_type, &feed_object::account >
+         >,
+         composite_key_compare< std::less< comment_id_type >, std::less< account_name_type > >
       >
    >,
    allocator< feed_object >
@@ -188,23 +192,24 @@ typedef multi_index_container<
       ordered_unique< tag< by_id >, member< blog_object, blog_id_type, &blog_object::id > >,
       ordered_unique< tag< by_blog >,
          composite_key< blog_object,
-            member< blog_object, account_id_type, &blog_object::account >,
+            member< blog_object, account_name_type, &blog_object::account >,
             member< blog_object, uint32_t, &blog_object::blog_feed_id >
          >,
-         composite_key_compare< std::less< account_id_type >, std::greater< uint32_t > >
+         composite_key_compare< std::less< account_name_type >, std::greater< uint32_t > >
       >,
       ordered_unique< tag< by_old_blog >,
          composite_key< blog_object,
-            member< blog_object, account_id_type, &blog_object::account >,
+            member< blog_object, account_name_type, &blog_object::account >,
             member< blog_object, uint32_t, &blog_object::blog_feed_id >
          >,
-         composite_key_compare< std::less< account_id_type >, std::less< uint32_t > >
+         composite_key_compare< std::less< account_name_type >, std::less< uint32_t > >
       >,
       ordered_unique< tag< by_comment >,
          composite_key< blog_object,
             member< blog_object, comment_id_type, &blog_object::comment >,
-            member< blog_object, account_id_type, &blog_object::account >
-         >
+            member< blog_object, account_name_type, &blog_object::account >
+         >,
+         composite_key_compare< std::less< comment_id_type >, std::less< account_name_type > >
       >
    >,
    allocator< blog_object >
@@ -219,11 +224,11 @@ typedef multi_index_container<
       ordered_unique< tag< by_reputation >,
          composite_key< reputation_object,
             member< reputation_object, share_type, &reputation_object::reputation >,
-            member< reputation_object, account_id_type, &reputation_object::account >
+            member< reputation_object, account_name_type, &reputation_object::account >
          >,
-         composite_key_compare< std::greater< share_type >, std::less< account_id_type > >
+         composite_key_compare< std::greater< share_type >, std::less< account_name_type > >
       >,
-      ordered_unique< tag< by_account >, member< reputation_object, account_id_type, &reputation_object::account > >
+      ordered_unique< tag< by_account >, member< reputation_object, account_name_type, &reputation_object::account > >
    >,
    allocator< reputation_object >
 > reputation_index;


### PR DESCRIPTION
Fixes a bug in the follow API introduced when the follow objects were updated to use account IDs instead of account names.