### PR TITLE
fixes for #36 #355 and #439

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -455,6 +455,7 @@ namespace detail {
                throw;
             }
          }
+         return false;
       } FC_CAPTURE_AND_RETHROW( (blk_msg)(sync_mode) ) }
 
       virtual void handle_transaction(const graphene::net::trx_message& transaction_message) override
@@ -962,6 +963,9 @@ void application::get_max_block_age( int32_t& result )
 
 void application::shutdown_plugins()
 {
+   my->_p2p_network->close();
+   my->_p2p_network.reset();
+   fc::usleep( fc::seconds(1) );
    for( auto& entry : my->_plugins_enabled )
       entry.second->plugin_shutdown();
    return;


### PR DESCRIPTION
Fixed crashes on exit by shutting down the network before shutting down plugins.  For good measure, I also added a small 1 second sleep so that any async calls could be processed.

Fixed crash on transaction confirmation by restructuring on_applied_block into a single ASYNC call that captured the signed_block. Rather than deleting the callback after calling it, I simply set it to an empty lambda.  Then on expiration I call everything and clean up.  

I also changed the > comparison for expiration to >= just incase there was some overlap.

Lastly I fixed a warning where handle_block() would exit without a return value if it wasn't "running".  This could cause the stack to get corrupted and crash on exit.