### PR TITLE
p2p and database have a co-dependency on shutdown. This breaks the co…

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -796,6 +796,7 @@ namespace detail {
       void shutdown()
       {
          _running = false;
+         fc::usleep( fc::seconds( 1 ) );
          if( _p2p_network )
             _p2p_network->close();
          if( _chain_db )
@@ -966,9 +967,6 @@ void application::get_max_block_age( int32_t& result )
 
 void application::shutdown_plugins()
 {
-   my->_p2p_network->close();
-   my->_p2p_network.reset();
-   fc::usleep( fc::seconds(1) );
    for( auto& entry : my->_plugins_enabled )
       entry.second->plugin_shutdown();
    return;


### PR DESCRIPTION
…mmunication between them, waits for in flight blocks to be applied, then shuts both down. Bump chainbase rev to have better lock handling if things break #607