### PR TITLE
The shared file directory is used when running in read only mode

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -308,7 +308,7 @@ namespace detail {
          else
          {
             ilog( "Starting Steem node in read mode." );
-            _chain_db->open( _data_dir / "blockchain", 0, _shared_file_size, chainbase::database::read_only );
+            _chain_db->open( _data_dir / "blockchain", _shared_dir, 0, _shared_file_size, chainbase::database::read_only );
 
             if( _options->count( "read-forward-rpc" ) )
             {


### PR DESCRIPTION
Fix segv when starting a read-only node.