### PR TITLE
Update GPO properties mirrored in witness_schedule_object

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -1509,32 +1509,33 @@ void database::update_median_witness_props()
    {
       return a->props.account_creation_fee.amount < b->props.account_creation_fee.amount;
    } );
-
-   modify( wso, [&]( witness_schedule_object& _wso )
-   {
-     _wso.median_props.account_creation_fee = active[active.size()/2]->props.account_creation_fee;
-   } );
+   asset median_account_creation_fee = active[active.size()/2]->props.account_creation_fee;
 
    /// sort them by maximum_block_size
    std::sort( active.begin(), active.end(), [&]( const witness_object* a, const witness_object* b )
    {
       return a->props.maximum_block_size < b->props.maximum_block_size;
    } );
-
-   modify( get_dynamic_global_properties(), [&]( dynamic_global_property_object& p )
-   {
-         p.maximum_block_size = active[active.size()/2]->props.maximum_block_size;
-   } );
+   uint32_t median_maximum_block_size = active[active.size()/2]->props.maximum_block_size;
 
    /// sort them by sbd_interest_rate
    std::sort( active.begin(), active.end(), [&]( const witness_object* a, const witness_object* b )
    {
       return a->props.sbd_interest_rate < b->props.sbd_interest_rate;
    } );
+   uint16_t median_sbd_interest_rate = active[active.size()/2]->props.sbd_interest_rate;
 
-   modify( get_dynamic_global_properties(), [&]( dynamic_global_property_object& p )
+   modify( wso, [&]( witness_schedule_object& _wso )
    {
-         p.sbd_interest_rate = active[active.size()/2]->props.sbd_interest_rate;
+      _wso.median_props.account_creation_fee = median_account_creation_fee;
+      _wso.median_props.maximum_block_size   = median_maximum_block_size;
+      _wso.median_props.sbd_interest_rate    = median_sbd_interest_rate;
+   } );
+
+   modify( get_dynamic_global_properties(), [&]( dynamic_global_property_object& _dgpo )
+   {
+      _dgpo.maximum_block_size = median_maximum_block_size;
+      _dgpo.sbd_interest_rate  = median_sbd_interest_rate;
    } );
 }
 


### PR DESCRIPTION
Also reduce the number of modify() calls needed.

See #682