### PR TITLE
673 tags filtering

### DIFF
--- a/libraries/plugins/tags/tags_plugin.cpp
+++ b/libraries/plugins/tags/tags_plugin.cpp
@@ -189,7 +189,8 @@ struct operation_visitor {
       }
 
       set< string > lower_tags;
-      meta.tags.insert( fc::to_lower( to_string( c.category ) ) );
+      if( c.category != "" )
+         meta.tags.insert( fc::to_lower( to_string( c.category ) ) );
 
       uint8_t tag_limit = 5;
       uint8_t count = 0;
@@ -204,10 +205,9 @@ struct operation_visitor {
       }
 
       /// the universal tag applies to everything safe for work or nsfw with a non-negative payout
-      if( c.net_rshares >= 0 ||
+      if( c.net_rshares >= 0 &&
          (lower_tags.find( "spam" ) == lower_tags.end() &&
-         lower_tags.find( "nsfw" ) == lower_tags.end() &&
-         lower_tags.find( "test" ) == lower_tags.end() )  )
+         lower_tags.find( "test" ) == lower_tags.end() ) )
       {
          lower_tags.insert( string() ); /// add it to the universal tag
       }

--- a/libraries/plugins/tags/tags_plugin.cpp
+++ b/libraries/plugins/tags/tags_plugin.cpp
@@ -189,31 +189,30 @@ struct operation_visitor {
       }
 
       set< string > lower_tags;
+      meta.tags.insert( fc::to_lower( to_string( c.category ) ) );
+
+      uint8_t tag_limit = 5;
+      uint8_t count = 0;
       for( const auto& tag : meta.tags )
-         lower_tags.insert( fc::to_lower( tag ) );
-
-      lower_tags.insert( fc::to_lower( to_string( c.category ) ) );
-
-
-      bool safe_for_work = false;
-      /// the universal tag applies to everything safe for work or nsfw with a positive payout
-      if( c.net_rshares >= 0 ||
-          (lower_tags.find( "spam" ) == lower_tags.end() &&
-           lower_tags.find( "nsfw" ) == lower_tags.end() &&
-           lower_tags.find( "test" ) == lower_tags.end() )  )
       {
-         safe_for_work = true;
+         ++count;
+         if( count > tag_limit || lower_tags.size() > tag_limit )
+            break;
+         if( tag == "" )
+            continue;
+         lower_tags.insert( fc::to_lower( tag ) );
+      }
+
+      /// the universal tag applies to everything safe for work or nsfw with a non-negative payout
+      if( c.net_rshares >= 0 ||
+         (lower_tags.find( "spam" ) == lower_tags.end() &&
+         lower_tags.find( "nsfw" ) == lower_tags.end() &&
+         lower_tags.find( "test" ) == lower_tags.end() )  )
+      {
          lower_tags.insert( string() ); /// add it to the universal tag
       }
 
       meta.tags = lower_tags; /// TODO: std::move???
-      if( meta.tags.size() > 5 ) {
-         //wlog( "ignoring post ${a} because it has ${n} tags",("a", c.author + "/"+c.permlink)("n",meta.tags.size()));
-         if( safe_for_work )
-            meta.tags = set< string >( {"", to_string( c.parent_permlink ) } );
-         else
-            meta.tags.clear();
-      }
 
 
       const auto& comment_idx = _db.get_index< tag_index >().indices().get< by_comment >();

--- a/libraries/plugins/tags/tags_plugin.cpp
+++ b/libraries/plugins/tags/tags_plugin.cpp
@@ -205,7 +205,7 @@ struct operation_visitor {
       }
 
       /// the universal tag applies to everything safe for work or nsfw with a non-negative payout
-      if( c.net_rshares >= 0 &&
+      if( c.net_rshares >= 0 ||
          (lower_tags.find( "spam" ) == lower_tags.end() &&
          lower_tags.find( "test" ) == lower_tags.end() ) )
       {


### PR DESCRIPTION
PR for #673

Correctly categorizes posts into 5 tags regardless if which tag is the "category" (parent_permlink).

Removes NSFW filtering from the global ranking to defer filtering to UI.