### PR TITLE
Seednodes update

### DIFF
--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -14,7 +14,7 @@ gtg.steem.house:2001           # gtg
 192.99.3.29:2001               # joseph
 5.9.18.213:2001                # pfunk
 lafonasteem.com:2001           # lafona
-52.63.172.229:2001             # rossco99
+seed.rossco99.com:2001         # rossco99
 212.47.249.84:40696            # ihashfury
 seed.steemfeeder.com:2001      # au1nethyb1
 ##### 104.40.230.35:2001             # aizensou # offline
@@ -27,7 +27,7 @@ steem.global:2001              # klye
 69.197.155.42:2001             # good-karma
 176.31.126.187:2001            # timcliff
 seed.royaltiffany.me:2001      # royaltiffany
-129.232.223.74:2001            # thecryptodrive
+seed.thecryptodrive.com:2001   # thecryptodrive
 steem-id.altexplorer.xyz:2001  # steem-id
 seed.bitcoiner.me:2001         # bitcoiner
 192.99.4.226:2001              # dele-puppy

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -20,7 +20,7 @@ seed.steemfeeder.com:2001      # au1nethyb1
 ##### 104.40.230.35:2001             # aizensou # offline
 seed.roelandp.nl:2001          # roelandp
 81.89.101.133:2001             # cyrano.witness
-45.55.54.83:2001               # tdv.witness
+##### 45.55.54.83:2001               # tdv.witness # offline
 ##### seed.steem.network:2001        # someguy123 # offline
 ##### 46.252.27.1:1337               # jabbasteem # offline
 steem.global:2001              # klye

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -11,6 +11,7 @@ seed.xeldal.com:12150          # xeldal
 seed.steemnodes.com:2001       # wackou
 steem.clawmap.com:2001         # steempty
 gtg.steem.house:2001           # gtg
+5.9.18.213:2001                # pfunk
 52.4.250.181:39705             # lafona
 52.63.172.229:2001             # rossco99
 212.47.249.84:40696            # ihashfury
@@ -23,6 +24,7 @@ gtg.steem.house:2001           # gtg
 ##### 46.252.27.1:1337               # jabbasteem # offline
 steem.global:2001              # klye
 ##### 104.196.141.163:2001           # good-karma # offline
+176.31.126.187:2001            # timcliff
 seed.royaltiffany.me:2001      # royaltiffany
 129.232.223.74:2001            # thecryptodrive
 steem-id.altexplorer.xyz:2001  # steem-id

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -6,6 +6,7 @@ steemwitness.matthewniemerg.com:2001 # complexring
 steemd.pharesim.me:2001        # pharesim
 seed.jesta.us:2001             # jesta
 212.117.213.186:2016           # liondani
+anyx.co:2001                   # anyx
 seed.xeldal.com:12150          # xeldal
 seed.steemnodes.com:2001       # wackou
 steem.clawmap.com:2001         # steempty

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -3,6 +3,7 @@ seed.riversteem.com:2001       # riverhead
 steem-seed1.abit-more.com:2001 # abit 
 52.74.152.79:2001              # smooth.witness
 seed.steemd.com:34191          # roadscape
+steemwitness.matthewniemerg.com:2001 # complexring
 steemd.pharesim.me:2001        # pharesim
 seed.jesta.us:2001             # jesta
 212.117.213.186:2016           # liondani

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -23,7 +23,7 @@ seed.roelandp.nl:2001          # roelandp
 ##### seed.steem.network:2001        # someguy123 # offline
 ##### 46.252.27.1:1337               # jabbasteem # offline
 steem.global:2001              # klye
-69.197.155.42:2001             # good-karma
+seed.esteem.ws:2001            # good-karma
 176.31.126.187:2001            # timcliff
 seed.royaltiffany.me:2001      # royaltiffany
 seed.thecryptodrive.com:2001   # thecryptodrive

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -33,3 +33,4 @@ seed.bitcoiner.me:2001         # bitcoiner
 104.198.222.18:2001            # bitcoinparadise
 138.197.17.188:2001            # chitty
 88.99.33.113:2001              # cervantes
+seed.bhuz.info:2001            # bhuz

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -1,5 +1,4 @@
 seed.riversteem.com:2001       # riverhead
-##### seed.steempower.org:2001       # charlieshrem # not resolved
 steem-seed1.abit-more.com:2001 # abit 
 52.74.152.79:2001              # smooth.witness
 seed.steemd.com:34191          # roadscape

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -16,7 +16,7 @@ gtg.steem.house:2001           # gtg
 52.4.250.181:39705             # lafona
 52.63.172.229:2001             # rossco99
 212.47.249.84:40696            # ihashfury
-##### 52.62.24.225:2001              # au1nethyb1 # offline
+##### seed.steemfeeder.com:2001      # au1nethyb1 # offline
 ##### 104.40.230.35:2001             # aizensou # offline
 ##### seed.roelandp.nl:2001          # roelandp # offline
 81.89.101.133:2001             # cyrano.witness
@@ -31,3 +31,6 @@ seed.royaltiffany.me:2001      # royaltiffany
 steem-id.altexplorer.xyz:2001  # steem-id
 seed.bitcoiner.me:2001         # bitcoiner
 192.99.4.226:2001              # ?
+89.36.26.82:2001               # dragosroua
+104.198.222.18:2001            # bitcoinparadise
+138.197.17.188:2001            # chitty

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -7,7 +7,6 @@ steemwitness.matthewniemerg.com:2001 # complexring
 steemd.pharesim.me:2001        # pharesim
 seed.jesta.us:2001             # jesta
 212.117.213.186:2016           # liondani
-##### anyx.co:2001                   # anyx # offline
 seed.xeldal.com:12150          # xeldal
 seed.steemnodes.com:2001       # wackou
 steem.clawmap.com:2001         # steempty
@@ -21,7 +20,6 @@ seed.steemfeeder.com:2001      # au1nethyb1
 52.175.211.168:2001            # aizensou
 seed.roelandp.nl:2001          # roelandp
 81.89.101.133:2001             # cyrano.witness
-##### 46.252.27.1:1337               # jabbasteem # offline
 steem.global:2001              # klye
 seed.esteem.ws:2001            # good-karma
 176.31.126.187:2001            # timcliff

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -23,7 +23,7 @@ gtg.steem.house:2001           # gtg
 ##### seed.steem.network:2001        # someguy123 # offline
 ##### 46.252.27.1:1337               # jabbasteem # offline
 steem.global:2001              # klye
-##### 104.196.141.163:2001           # good-karma # offline
+69.197.155.42:2001             # good-karma
 176.31.126.187:2001            # timcliff
 seed.royaltiffany.me:2001      # royaltiffany
 129.232.223.74:2001            # thecryptodrive

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -20,7 +20,6 @@ seed.steemfeeder.com:2001      # au1nethyb1
 ##### 104.40.230.35:2001             # aizensou # offline
 seed.roelandp.nl:2001          # roelandp
 81.89.101.133:2001             # cyrano.witness
-##### seed.steem.network:2001        # someguy123 # offline
 ##### 46.252.27.1:1337               # jabbasteem # offline
 steem.global:2001              # klye
 seed.esteem.ws:2001            # good-karma

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -1,12 +1,12 @@
 seed.riversteem.com:2001       # riverhead
-seed.steempower.org:2001       # charlieshrem
+##### seed.steempower.org:2001       # charlieshrem # not resolved
 steem-seed1.abit-more.com:2001 # abit 
 52.74.152.79:2001              # smooth.witness
 seed.steemd.com:34191          # roadscape
-steemd.pharesim.me:2001        # pharesim
+##### steemd.pharesim.me:2001        # pharesim # offline
 seed.jesta.us:2001             # jesta
 212.117.213.186:2016           # liondani
-anyx.co:2001                   # anyx
+##### anyx.co:2001                   # anyx # offline
 seed.xeldal.com:12150          # xeldal
 seed.steemnodes.com:2001       # wackou
 steem.clawmap.com:2001         # steempty
@@ -14,20 +14,17 @@ gtg.steem.house:2001           # gtg
 52.4.250.181:39705             # lafona
 52.63.172.229:2001             # rossco99
 212.47.249.84:40696            # ihashfury
-52.62.24.225:2001              # au1nethyb1
-104.40.230.35:2001             # aizensou
-seed.roelandp.nl:2001          # roelandp
+##### 52.62.24.225:2001              # au1nethyb1 # offline
+##### 104.40.230.35:2001             # aizensou # offline
+##### seed.roelandp.nl:2001          # roelandp # offline
 81.89.101.133:2001             # cyrano.witness
 45.55.54.83:2001               # tdv.witness
-seed.steem.network:2001        # someguy123
-46.252.27.1:1337               # jabbasteem
+##### seed.steem.network:2001        # someguy123 # offline
+##### 46.252.27.1:1337               # jabbasteem # offline
 steem.global:2001              # klye
-104.196.141.163:2001           # good-karma
+##### 104.196.141.163:2001           # good-karma # offline
 seed.royaltiffany.me:2001      # royaltiffany
 129.232.223.74:2001            # thecryptodrive
 steem-id.altexplorer.xyz:2001  # steem-id
 seed.bitcoiner.me:2001         # bitcoiner
-52.26.78.244:2001              # ?
-52.37.169.52:2001              # ?
-52.38.66.234:2001              # ?
 192.99.4.226:2001              # ?

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -16,7 +16,7 @@ gtg.steem.house:2001           # gtg
 lafonasteem.com:2001           # lafona
 52.63.172.229:2001             # rossco99
 212.47.249.84:40696            # ihashfury
-##### seed.steemfeeder.com:2001      # au1nethyb1 # offline
+seed.steemfeeder.com:2001      # au1nethyb1
 ##### 104.40.230.35:2001             # aizensou # offline
 seed.roelandp.nl:2001          # roelandp
 81.89.101.133:2001             # cyrano.witness

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -30,7 +30,7 @@ seed.royaltiffany.me:2001      # royaltiffany
 129.232.223.74:2001            # thecryptodrive
 steem-id.altexplorer.xyz:2001  # steem-id
 seed.bitcoiner.me:2001         # bitcoiner
-192.99.4.226:2001              # ?
+192.99.4.226:2001              # dele-puppy
 89.36.26.82:2001               # dragosroua
 104.198.222.18:2001            # bitcoinparadise
 138.197.17.188:2001            # chitty

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -33,3 +33,4 @@ seed.bitcoiner.me:2001         # bitcoiner
 89.36.26.82:2001               # dragosroua
 104.198.222.18:2001            # bitcoinparadise
 138.197.17.188:2001            # chitty
+88.99.33.113:2001              # cervantes

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -13,7 +13,7 @@ steem.clawmap.com:2001         # steempty
 gtg.steem.house:2001           # gtg
 192.99.3.29:2001               # joseph
 5.9.18.213:2001                # pfunk
-52.4.250.181:39705             # lafona
+lafonasteem.com:2001           # lafona
 52.63.172.229:2001             # rossco99
 212.47.249.84:40696            # ihashfury
 ##### seed.steemfeeder.com:2001      # au1nethyb1 # offline

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -17,7 +17,7 @@ lafonasteem.com:2001           # lafona
 seed.rossco99.com:2001         # rossco99
 212.47.249.84:40696            # ihashfury
 seed.steemfeeder.com:2001      # au1nethyb1
-##### 104.40.230.35:2001             # aizensou # offline
+52.175.211.168:2001            # aizensou
 seed.roelandp.nl:2001          # roelandp
 81.89.101.133:2001             # cyrano.witness
 ##### 46.252.27.1:1337               # jabbasteem # offline

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -3,7 +3,7 @@ seed.riversteem.com:2001       # riverhead
 steem-seed1.abit-more.com:2001 # abit 
 52.74.152.79:2001              # smooth.witness
 seed.steemd.com:34191          # roadscape
-##### steemd.pharesim.me:2001        # pharesim # offline
+steemd.pharesim.me:2001        # pharesim
 seed.jesta.us:2001             # jesta
 212.117.213.186:2016           # liondani
 ##### anyx.co:2001                   # anyx # offline
@@ -20,7 +20,6 @@ seed.steemfeeder.com:2001      # au1nethyb1
 ##### 104.40.230.35:2001             # aizensou # offline
 seed.roelandp.nl:2001          # roelandp
 81.89.101.133:2001             # cyrano.witness
-##### 45.55.54.83:2001               # tdv.witness # offline
 ##### seed.steem.network:2001        # someguy123 # offline
 ##### 46.252.27.1:1337               # jabbasteem # offline
 steem.global:2001              # klye

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -18,7 +18,7 @@ gtg.steem.house:2001           # gtg
 212.47.249.84:40696            # ihashfury
 ##### seed.steemfeeder.com:2001      # au1nethyb1 # offline
 ##### 104.40.230.35:2001             # aizensou # offline
-##### seed.roelandp.nl:2001          # roelandp # offline
+seed.roelandp.nl:2001          # roelandp
 81.89.101.133:2001             # cyrano.witness
 45.55.54.83:2001               # tdv.witness
 ##### seed.steem.network:2001        # someguy123 # offline

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -11,6 +11,7 @@ seed.xeldal.com:12150          # xeldal
 seed.steemnodes.com:2001       # wackou
 steem.clawmap.com:2001         # steempty
 gtg.steem.house:2001           # gtg
+192.99.3.29:2001               # joseph
 5.9.18.213:2001                # pfunk
 52.4.250.181:39705             # lafona
 52.63.172.229:2001             # rossco99

--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -29,6 +29,7 @@ seed.royaltiffany.me:2001      # royaltiffany
 seed.thecryptodrive.com:2001   # thecryptodrive
 steem-id.altexplorer.xyz:2001  # steem-id
 seed.bitcoiner.me:2001         # bitcoiner
+104.199.118.92:2001            # clayop
 192.99.4.226:2001              # dele-puppy
 89.36.26.82:2001               # dragosroua
 104.198.222.18:2001            # bitcoinparadise


### PR DESCRIPTION
Up to date list of current operating seed nodes
including updates from community members,
removed nodes that failed to respond even once for 100h

Output of `sed -e 's/^/seed-node = /' seednodes.txt`
can be added to `config.ini` file