### PR TITLE
Delegated SP Fixes

### DIFF
--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -2262,7 +2262,7 @@ void delegate_vesting_shares_evaluator::do_apply( const delegate_vesting_shares_
       });
    }
    // Else if the delegation is increasing
-   else if( op.vesting_shares > delegation->vesting_shares )
+   else if( op.vesting_shares >= delegation->vesting_shares )
    {
       FC_ASSERT( op.vesting_shares - delegation->vesting_shares >= min_update, "Steem Power increase is not enough of a different. min_update: ${min}", ("min", min_update) );
       FC_ASSERT( available_shares >= op.vesting_shares - delegation->vesting_shares, "Account does not have enough vesting shares to delegate." );
@@ -2285,7 +2285,7 @@ void delegate_vesting_shares_evaluator::do_apply( const delegate_vesting_shares_
       });
    }
    // Else the delegation is decreasing
-   else if( delegation->vesting_shares > op.vesting_shares )
+   else /* delegation->vesting_shares > op.vesting_shares */
    {
       FC_ASSERT( delegation->vesting_shares - op.vesting_shares >= min_delegation || op.vesting_shares.amount == 0, "Delegation must be removed or leave minimum delegation amount of ${v}", ("v", min_delegation) );
 
@@ -2314,10 +2314,6 @@ void delegate_vesting_shares_evaluator::do_apply( const delegate_vesting_shares_
       {
          _db.remove( *delegation );
       }
-   }
-   else
-   {
-      FC_ASSERT( false, "Delegation must change by at least ${v}", ("v", min_update) );
    }
 }
 

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -2262,8 +2262,9 @@ void delegate_vesting_shares_evaluator::do_apply( const delegate_vesting_shares_
       });
    }
    // Else if the delegation is increasing
-   else if( op.vesting_shares - delegation->vesting_shares >= min_update )
+   else if( op.vesting_shares > delegation->vesting_shares )
    {
+      FC_ASSERT( op.vesting_shares - delegation->vesting_shares >= min_update, "Steem Power increase is not enough of a different. min_update: ${min}", ("min", min_update) );
       FC_ASSERT( available_shares >= op.vesting_shares - delegation->vesting_shares, "Account does not have enough vesting shares to delegate." );
 
       auto delta = op.vesting_shares - delegation->vesting_shares;
@@ -2284,11 +2285,9 @@ void delegate_vesting_shares_evaluator::do_apply( const delegate_vesting_shares_
       });
    }
    // Else the delegation is decreasing
-   else if( delegation->vesting_shares - op.vesting_shares >= min_update || delegation->vesting_shares == op.vesting_shares )
+   else if( delegation->vesting_shares > op.vesting_shares )
    {
-      FC_ASSERT( delegation->min_delegation_time <= _db.head_block_time(), "Delegation cannot be removed yet." );
-      if( delegation->vesting_shares != op.vesting_shares )
-         FC_ASSERT( delegation->vesting_shares - op.vesting_shares >= min_delegation, "Delegation must be removed or leave minimum delegation amount of ${v}", ("v", min_delegation) );
+      FC_ASSERT( delegation->vesting_shares - op.vesting_shares >= min_delegation || op.vesting_shares.amount == 0, "Delegation must be removed or leave minimum delegation amount of ${v}", ("v", min_delegation) );
 
       auto delta = delegation->vesting_shares - op.vesting_shares;
 
@@ -2296,7 +2295,7 @@ void delegate_vesting_shares_evaluator::do_apply( const delegate_vesting_shares_
       {
          obj.delegator = op.delegator;
          obj.vesting_shares = delta;
-         obj.expiration = _db.head_block_time() + STEEMIT_CASHOUT_WINDOW_SECONDS; // TODO: Replace with config constant with payout change branch
+         obj.expiration = std::max( _db.head_block_time() + STEEMIT_CASHOUT_WINDOW_SECONDS, delegation->min_delegation_time );
       });
 
       _db.modify( delegatee, [&]( account_object& a )

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -6316,13 +6316,19 @@ BOOST_AUTO_TEST_CASE( delegate_vesting_shares_apply )
 
       auto sam_vest = db.get_account( "sam" ).vesting_shares;
 
-      BOOST_TEST_MESSAGE( "--- Testing failure delegating more vesting shares than account has." );
+      BOOST_TEST_MESSAGE( "--- Test failure when delegating 0 VESTS" );
       tx.clear();
       op.delegator = "sam";
       op.delegatee = "dave";
+      tx.set_expiration( db.head_block_time() + STEEMIT_MAX_TIME_UNTIL_EXPIRATION );
+      tx.sign( sam_private_key, db.get_chain_id() );
+      STEEMIT_REQUIRE_THROW( db.push_transaction( tx ), fc::assert_exception );
+
+
+      BOOST_TEST_MESSAGE( "--- Testing failure delegating more vesting shares than account has." );
+      tx.clear();
       op.vesting_shares = asset( sam_vest.amount + 1, VESTS_SYMBOL );
       tx.operations.push_back( op );
-      tx.set_expiration( db.head_block_time() + STEEMIT_MAX_TIME_UNTIL_EXPIRATION );
       tx.sign( sam_private_key, db.get_chain_id() );
       STEEMIT_REQUIRE_THROW( db.push_transaction( tx ), fc::assert_exception );
 

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -5999,8 +5999,11 @@ BOOST_AUTO_TEST_CASE( account_create_with_delegation_apply )
 
       BOOST_REQUIRE( delegation != nullptr);
       BOOST_REQUIRE( delegation->delegator == op.creator);
+      BOOST_REQUIRE( delegation->delegatee == op.new_account_name );
       BOOST_REQUIRE( delegation->vesting_shares == ASSET( "10000.000000 VESTS" ) );
       BOOST_REQUIRE( delegation->min_delegation_time == db.head_block_time() + STEEMIT_CREATE_ACCOUNT_DELEGATION_TIME );
+      auto del_amt = delegation->vesting_shares;
+      auto exp_time = delegation->min_delegation_time;
 
       generate_block();
 
@@ -6040,6 +6043,24 @@ BOOST_AUTO_TEST_CASE( account_create_with_delegation_apply )
       fund( "alice" , asset( db.get_witness_schedule_object().median_props.account_creation_fee.amount * STEEMIT_CREATE_ACCOUNT_WITH_STEEM_MODIFIER * STEEMIT_CREATE_ACCOUNT_DELEGATION_RATIO , STEEM_SYMBOL ));
       STEEMIT_REQUIRE_THROW( db.push_transaction( tx, 0 ), fc::exception );
 
+      validate_database();
+
+      tx.clear();
+      delegate_vesting_shares_operation delegate;
+      delegate.delegator = "alice";
+      delegate.delegatee = "bob";
+      delegate.vesting_shares = ASSET( "0.000000 VESTS" );
+      tx.operations.push_back( delegate );
+      tx.sign( alice_private_key, db.get_chain_id() );
+      db.push_transaction( tx, 0 );
+
+      auto itr = db.get_index< vesting_delegation_expiration_index, by_id >().begin();
+      auto end = db.get_index< vesting_delegation_expiration_index, by_id >().end();
+
+      BOOST_REQUIRE( itr != end );
+      BOOST_REQUIRE( itr->delegator == "alice" );
+      BOOST_REQUIRE( itr->vesting_shares == del_amt );
+      BOOST_REQUIRE( itr->expiration == exp_time );
       validate_database();
    }
    FC_LOG_AND_RETHROW()


### PR DESCRIPTION
This fixes some bugs in the delegation logic. It also allows delegations for account creation to be removed immediately, but while still requiring the creator to lock their steem power for 30 days.