### PR TITLE
show witness and latency on 'Got block' messages

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -489,11 +489,14 @@ namespace detail {
                // leave that peer connected so that they can get sync blocks from us
                bool result = _chain_db->push_block(blk_msg.block, (_is_block_producer | _force_validate) ? database::skip_nothing : database::skip_transaction_signatures);
 
-               if( !sync_mode && blk_msg.block.transactions.size() )
+               if( !sync_mode )
                {
-                  ilog( "Got ${t} transactions from network on block ${b}",
+                  fc::microseconds latency = fc::time_point::now() - blk_msg.block.timestamp;
+                  ilog( "Got ${t} transactions on block ${b} by ${w} -- latency: ${l} ms",
                      ("t", blk_msg.block.transactions.size())
-                     ("b", blk_msg.block.block_num()) );
+                     ("b", blk_msg.block.block_num())
+                     ("w", blk_msg.block.witness)
+                     ("l", latency.count() / 1000) );
                }
 
                return result;


### PR DESCRIPTION
This can greatly help with debugging witness/fork issues.

adapted from https://github.com/abitmore/steem/tree/v0.16.0-a-bit-more-logs

sample output:

```
777275ms th_a       application.cpp:499           handle_block         ] Got 8 transactions on block 10405693 by jesta -- latency: 275 ms
780250ms th_a       application.cpp:499           handle_block         ] Got 7 transactions on block 10405694 by roelandp -- latency: 250 ms
783214ms th_a       application.cpp:499           handle_block         ] Got 4 transactions on block 10405695 by good-karma -- latency: 214 ms
786271ms th_a       application.cpp:499           handle_block         ] Got 9 transactions on block 10405696 by pfunk -- latency: 271 ms
789392ms th_a       application.cpp:499           handle_block         ] Got 9 transactions on block 10405697 by blocktrades -- latency: 392 ms
792227ms th_a       application.cpp:499           handle_block         ] Got 5 transactions on block 10405698 by witness.svk -- latency: 227 ms
795292ms th_a       application.cpp:499           handle_block         ] Got 5 transactions on block 10405699 by charlieshrem -- latency: 292 ms
798148ms th_a       application.cpp:499           handle_block         ] Got 10 transactions on block 10405700 by roadscape -- latency: 148 ms
801571ms th_a       application.cpp:499           handle_block         ] Got 5 transactions on block 10405701 by abit -- latency: 571 ms
804455ms th_a       application.cpp:499           handle_block         ] Got 8 transactions on block 10405702 by pharesim -- latency: 455 ms
807247ms th_a       application.cpp:499           handle_block         ] Got 13 transactions on block 10405703 by arhag -- latency: 247 ms
810391ms th_a       application.cpp:499           handle_block         ] Got 8 transactions on block 10405704 by klye -- latency: 391 ms
813225ms th_a       application.cpp:499           handle_block         ] Got 7 transactions on block 10405705 by gtg -- latency: 225 ms
816168ms th_a       application.cpp:499           handle_block         ] Got 7 transactions on block 10405706 by xeldal -- latency: 168 ms
819288ms th_a       application.cpp:499           handle_block         ] Got 7 transactions on block 10405707 by yme-08 -- latency: 288 ms
822231ms th_a       application.cpp:499           handle_block         ] Got 8 transactions on block 10405708 by bhuz -- latency: 231 ms
825416ms th_a       application.cpp:499           handle_block         ] Got 7 transactions on block 10405709 by clayop -- latency: 416 ms
828382ms th_a       application.cpp:499           handle_block         ] Got 12 transactions on block 10405710 by smooth.witness -- latency: 382 ms
831476ms th_a       application.cpp:499           handle_block         ] Got 10 transactions on block 10405711 by pharesim -- latency: 476 ms
```