### PR TITLE
Clarify number of witnesses to HF Comment

### DIFF
--- a/libraries/protocol/include/steemit/protocol/config.hpp
+++ b/libraries/protocol/include/steemit/protocol/config.hpp
@@ -90,7 +90,7 @@
 #define STEEMIT_MAX_MINER_WITNESSES_HF17        0
 #define STEEMIT_MAX_RUNNER_WITNESSES_HF17       1
 
-#define STEEMIT_HARDFORK_REQUIRED_WITNESSES     17 // 17 of the 20 dpos witnesses (19 elected and 1 virtual time) required for hardfork. This guarantees 75% participation on all subsequent rounds.
+#define STEEMIT_HARDFORK_REQUIRED_WITNESSES     17 // 17 of the 21 dpos witnesses (20 elected and 1 virtual time) required for hardfork. This guarantees 75% participation on all subsequent rounds.
 #define STEEMIT_MAX_TIME_UNTIL_EXPIRATION       (60*60) // seconds,  aka: 1 hour
 #define STEEMIT_MAX_MEMO_SIZE                   2048
 #define STEEMIT_MAX_PROXY_RECURSION_DEPTH       4


### PR DESCRIPTION
PR for #1042

>In HF 17/18, the POW miner position was removed, and an additional top elected witness was added. There are now 20 'top witnesses' and 1 backup witness per round.
>
>The comment in the code describing STEEMIT_HARDFORK_REQUIRED_WITNESSES was not updated to indicate that there are now 21 DPOS witnesses (20 elected and 1 backup).
>
>This PR corrects the comment.