### PR TITLE
Implement test for fixed_string

### DIFF
--- a/programs/util/CMakeLists.txt
+++ b/programs/util/CMakeLists.txt
@@ -78,3 +78,15 @@ install( TARGETS
    LIBRARY DESTINATION lib
    ARCHIVE DESTINATION lib
 )
+
+add_executable( test_fixed_string test_fixed_string.cpp )
+target_link_libraries( test_fixed_string
+                       PRIVATE steemit_chain steemit_protocol fc ${CMAKE_DL_LIB} ${PLATFORM_SPECIFIC_LIBS} )
+
+install( TARGETS
+   test_fixed_string
+
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib
+)

--- a/programs/util/test_fixed_string.cpp
+++ b/programs/util/test_fixed_string.cpp
@@ -1,0 +1,169 @@
+
+#include <steemit/protocol/fixed_string.hpp>
+
+#include <fc/io/raw.hpp>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+inline int popcount( uint32_t x )
+{
+   int result = 0;
+   for( size_t i=0; i<8*sizeof(x); i++ )
+   {
+      result += (x&1);
+      x >>= 1;
+   }
+   return result;
+}
+
+int errors = 0;
+
+void check( const std::string& s, const std::string& t,
+    bool cond )
+{
+   if( !cond )
+   {
+      std::cout << "problem with " << s << " " << t << std::endl;
+      ++errors;
+   }
+}
+
+void check_variant( const std::string& s, const steemit::protocol::fixed_string& fs )
+{
+   fc::variant vs, vfs;
+   fc::to_variant( s, vs );
+   fc::to_variant( fs, vfs );
+   if( !(vs.is_string() && vfs.is_string() &&
+         (vs.get_string() == s) && (vfs.get_string() == s)
+     )  )
+   {
+      std::cout << "to_variant() check failed on " << s << std::endl;
+      ++errors;
+   }
+
+   std::string s2;
+   steemit::protocol::fixed_string fs2;
+   fc::from_variant( vs, s2 );
+   fc::from_variant( vfs, fs2 );
+   if( s2 != s )
+   {
+      std::cout << "from_variant() check failed on " << s << std::endl;
+      ++errors;
+   }
+
+   if( fs2 != fs )
+   {
+      std::cout << "from_variant() check failed on " << s << std::endl;
+      ++errors;
+   }
+}
+
+void check_pack( const std::string& s, const steemit::protocol::fixed_string& fs )
+{
+   std::stringstream ss, sfs;
+   fc::raw::pack( ss, s );
+   fc::raw::pack( sfs, fs );
+   std::string packed = ss.str();
+   if( packed != sfs.str() )
+   {
+      std::cout << "check_pack() check failed on " << s << std::endl;
+      ++errors;
+   }
+
+   ss.seekg(0);
+   steemit::protocol::fixed_string unpacked;
+   fc::raw::unpack( ss, unpacked );
+   if( unpacked != fs )
+   {
+      std::cout << "check_pack() check failed on " << s << std::endl;
+      ++errors;
+   }
+}
+
+int main( int argc, char** argv, char** envp )
+{
+   std::vector< std::string > all_strings;
+   std::vector< steemit::protocol::fixed_string > all_fixed_strings;
+   std::vector< std::vector< uint32_t > > sim_index;
+
+   std::cout << "setting up LUT's" << std::endl;
+   for( int len=0; len<=16; len++ )
+   {
+      int b_max = 1 << len;
+      size_t begin_offset = all_strings.size();
+
+      std::vector< uint32_t > hops;
+      for( int b=0; b<b_max; b++ )
+      {
+         uint32_t ub = uint32_t(b);
+         if( popcount(ub) <= 3 )
+            hops.push_back( ub );
+      }
+
+      for( int b=0; b<b_max; b++ )
+      {
+         all_strings.emplace_back(len, '\0');
+         for( int i=0,m=1; i<len; i++,m+=m )
+         {
+            all_strings.back()[len-i-1] = ((b&m)==0) ? 'a' : 'b';
+         }
+
+         sim_index.emplace_back();
+         for( const uint32_t& h : hops )
+         {
+            sim_index.back().push_back(begin_offset + (b^h));
+         }
+      }
+   }
+
+   /*
+   for( size_t i=0; i<all_strings.size(); i++ )
+   {
+      std::cout << all_strings[i] << std::endl;
+      for( const uint32_t& j : sim_index[i] )
+         std::cout << "   " << all_strings[j] << std::endl;
+   }
+   */
+
+   std::cout << "checking conversions, size(), comparison operators" << std::endl;
+
+   for( size_t i=0; i<all_strings.size(); i++ )
+   {
+      const std::string& s = all_strings[i];
+      steemit::protocol::fixed_string fs(s);
+      std::string sfs = fs;
+      if( s != fs )
+      {
+         std::cout << "problem on " << s << std::endl;
+         ++errors;
+      }
+      if( fs.size() != s.size() )
+      {
+         std::cout << "problem on " << s << std::endl;
+         ++errors;
+      }
+
+      check_variant( s, fs );
+      check_pack( s, fs );
+
+      for( const uint32_t& j : sim_index[i] )
+      {
+         const std::string& t = all_strings[j];
+         steemit::protocol::fixed_string ft(t);
+         check( s, t, (s< t) == (fs< ft) );
+         check( s, t, (s<=t) == (fs<=ft) );
+         check( s, t, (s> t) == (fs> ft) );
+         check( s, t, (s>=t) == (fs>=ft) );
+         check( s, t, (s==t) == (fs==ft) );
+         check( s, t, (s!=t) == (fs!=ft) );
+      }
+   }
+
+   std::cout << "test_fixed_string found " << errors << " errors" << std::endl;
+
+   int result = (errors == 0) ? 0 : 1;
+   return result;
+}


### PR DESCRIPTION
Some code I had for testing my never-completed PR for #951.  The #1084 code passes with flying colors!

This isn't in the test suite because it takes a while to run.  It's a one-off check for the implementation of the comparison and conversion operators, part of the code that really shouldn't be subject to regressions once it's written and initially tested.