### PR TITLE
Remove false comment

### DIFF
--- a/libraries/chain/witness_schedule.cpp
+++ b/libraries/chain/witness_schedule.cpp
@@ -259,7 +259,6 @@ void update_witness_schedule4( database& db )
 
    db.modify( wso, [&]( witness_schedule_object& _wso )
    {
-      // active witnesses has exactly STEEMIT_MAX_WITNESSES elements, asserted above
       for( size_t i = 0; i < active_witnesses.size(); i++ )
       {
          _wso.current_shuffled_witnesses[i] = active_witnesses[i];


### PR DESCRIPTION
Removed comment claimed that `active_witnesses.size()` is exactly `STEEMIT_MAX_WITNESSES`, but this is flatly false, and the code immediately following it even iterates from `active_witnesses.size()` up to `STEEMIT_MAX_WITNESSES` which would obviously be a nop if that comment were correct. Also, the assertion the comment ostensibly refers to (line 184) asserts that `active_witnesses.size()` is either equal to `STEEMIT_MAX_WITNESSES` or something else, so obviously it is not guaranteed that these will be equal.