### PR TITLE
remove account_history plugin from default/low memory config file

### DIFF
--- a/contrib/config-for-docker.ini
+++ b/contrib/config-for-docker.ini
@@ -38,7 +38,7 @@ enable-plugin = witness account_history
 bcd-trigger = [[0,10],[85,300]]
 
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to]
-# track-account-range = 
+track-account-range = ["",""] 
 
 # Ignore posting operations, only track transfers and account updates
 # filter-posting-ops = 

--- a/contrib/config-for-docker.ini
+++ b/contrib/config-for-docker.ini
@@ -32,13 +32,13 @@
 public-api = database_api login_api
 
 # Plugin(s) to enable, may be specified multiple times
-enable-plugin = witness account_history
+enable-plugin = witness
 
 # JSON list of [nblocks,nseconds] pairs, see doc/bcd-trigger.md
 bcd-trigger = [[0,10],[85,300]]
 
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to]
-track-account-range = ["",""] 
+# track-account-range =
 
 # Ignore posting operations, only track transfers and account updates
 # filter-posting-ops = 

--- a/contrib/steemd.run
+++ b/contrib/steemd.run
@@ -26,7 +26,7 @@ fi
 
 # if user did pass in desired seed nodes, use
 # the ones the user specified:
-if [[ ! -z "$STEEMD_SEED_NODES" ]]; then
+if [[ ! -z "$STEEMD_SEED_NODES" ]]; then 
     for NODE in $STEEMD_SEED_NODES ; do
         ARGS+=" --seed-node=$NODE"
     done
@@ -46,7 +46,10 @@ if [[ ! -z "$STEEMD_PRIVATE_KEY" ]]; then
 fi
 
 if [[ ! -z "$TRACK_ACCOUNT" ]]; then
-    ARGS+=" --track-account-range=[\"$TRACK_ACCOUNT\",\"$TRACK_ACCOUNT\"]"
+    if [[ ! "$USE_WAY_TOO_MUCH_RAM" ]]; then
+        ARGS+=" --enable-plugin=witness account_history"
+    fi
+    ARGS+="  --track-account-range=[\"$TRACK_ACCOUNT\",\"$TRACK_ACCOUNT\"]"
 fi
 
 NOW=`date +%s`

--- a/contrib/steemd.run
+++ b/contrib/steemd.run
@@ -45,6 +45,10 @@ if [[ ! -z "$STEEMD_PRIVATE_KEY" ]]; then
     ARGS+=" --private-key=$STEEMD_PRIVATE_KEY"
 fi
 
+if [[ ! -z "$TRACK_ACCOUNT" ]]; then
+    ARGS+=" --track-account-range=[\"$TRACK_ACCOUNT\",\"$TRACK_ACCOUNT\"]"
+fi
+
 NOW=`date +%s`
 STEEMD_FEED_START_TIME=`expr $NOW - 1209600`
 STEEMD_FEED_START_TIMESTAMP=`date --date=@$STEEMD_FEED_START_TIME +%Y-%m-%d:%H:%M:%S`

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -37,6 +37,12 @@ track-account-range = ["yourexchangeid", "yourexchangeid"]
 ```
 Do not add other APIs or plugins unless you know what you are doing.
 
+This configuration exists in Docker with the following command
+
+```
+docker run -d --env TRACK_ACCOUNT="yourexchangeid" steemit/steem
+```
+
 ### Resources usage
 
 Please make sure that you have enough resources available.


### PR DESCRIPTION
to speed up the ability to sync when simply running `docker run -it steemit/steem`