### PR TITLE
Very minor cleanup of tags plugin #1161

### DIFF
--- a/libraries/plugins/tags/tags_plugin.cpp
+++ b/libraries/plugins/tags/tags_plugin.cpp
@@ -409,7 +409,7 @@ struct operation_visitor {
 
       auto meta = filter_tags( c );
 
-      for( auto tag : meta.tags )
+      for( const string& tag : meta.tags )
       {
          _db.modify( get_stats( tag ), [&]( tag_stats_object& ts )
          {

--- a/libraries/plugins/tags/tags_plugin.cpp
+++ b/libraries/plugins/tags/tags_plugin.cpp
@@ -48,28 +48,40 @@ tags_plugin_impl::~tags_plugin_impl()
    return;
 }
 
-struct operation_visitor {
+struct operation_visitor
+{
    operation_visitor( database& db ):_db(db){};
    typedef void result_type;
 
    database& _db;
 
-   void remove_stats( const tag_object& tag, const tag_stats_object& stats )const {
-      _db.modify( stats, [&]( tag_stats_object& s ) {
-           if( tag.parent == comment_id_type() ) {
+   void remove_stats( const tag_object& tag, const tag_stats_object& stats )const
+   {
+      _db.modify( stats, [&]( tag_stats_object& s )
+      {
+           if( tag.parent == comment_id_type() )
+           {
               s.top_posts--;
-           } else {
+           }
+           else
+           {
               s.comments--;
            }
            s.total_trending -= static_cast<uint32_t>(tag.trending);
            s.net_votes   -= tag.net_votes;
       });
    }
-   void add_stats( const tag_object& tag, const tag_stats_object& stats )const {
-      _db.modify( stats, [&]( tag_stats_object& s ) {
-           if( tag.parent == comment_id_type() ) {
+
+   void add_stats( const tag_object& tag, const tag_stats_object& stats )const
+   {
+      _db.modify( stats, [&]( tag_stats_object& s )
+      {
+           if( tag.parent == comment_id_type() )
+           {
               s.top_posts++;
-           } else {
+           }
+           else
+           {
               s.comments++;
            }
            s.total_trending += static_cast<uint32_t>(tag.trending);
@@ -77,27 +89,33 @@ struct operation_visitor {
       });
    }
 
-   void remove_tag( const tag_object& tag )const {
+   void remove_tag( const tag_object& tag )const
+   {
       /// TODO: update tag stats object
       _db.remove(tag);
 
       const auto& idx = _db.get_index<author_tag_stats_index>().indices().get<by_author_tag_posts>();
       auto itr = idx.lower_bound( boost::make_tuple(tag.author,tag.tag) );
-      if( itr != idx.end() && itr->author == tag.author && itr->tag == tag.tag ) {
-         _db.modify( *itr, [&]( author_tag_stats_object& stats ) {
+      if( itr != idx.end() && itr->author == tag.author && itr->tag == tag.tag )
+      {
+         _db.modify( *itr, [&]( author_tag_stats_object& stats )
+         {
             stats.total_posts--;
          });
       }
    }
 
-   const tag_stats_object& get_stats( const string& tag )const {
+   const tag_stats_object& get_stats( const string& tag )const
+   {
       const auto& stats_idx = _db.get_index<tag_stats_index>().indices().get<by_tag>();
       auto itr = stats_idx.find( tag );
-      if( itr != stats_idx.end() ) return *itr;
+      if( itr != stats_idx.end() )
+         return *itr;
 
-      return _db.create<tag_stats_object>( [&]( tag_stats_object& stats ) {
-                  stats.tag = tag;
-              });
+      return _db.create<tag_stats_object>( [&]( tag_stats_object& stats )
+      {
+         stats.tag = tag;
+      });
    }
 
    comment_metadata filter_tags( const comment_object& c ) const
@@ -168,14 +186,15 @@ struct operation_visitor {
    }
 
    void create_tag( const string& tag, const comment_object& comment, double hot, double trending )const
-{
+   {
       comment_id_type parent;
       account_id_type author = _db.get_account( comment.author ).id;
 
       if( comment.parent_author.size() )
          parent = _db.get_comment( comment.parent_author, comment.parent_permlink ).id;
 
-      const auto& tag_obj = _db.create<tag_object>( [&]( tag_object& obj ) {
+      const auto& tag_obj = _db.create<tag_object>( [&]( tag_object& obj )
+      {
           obj.tag               = tag;
           obj.comment           = comment.id;
           obj.parent            = parent;
@@ -194,12 +213,17 @@ struct operation_visitor {
 
       const auto& idx = _db.get_index<author_tag_stats_index>().indices().get<by_author_tag_posts>();
       auto itr = idx.lower_bound( boost::make_tuple(author,tag) );
-      if( itr != idx.end() && itr->author == author && itr->tag == tag ) {
-         _db.modify( *itr, [&]( author_tag_stats_object& stats ) {
+      if( itr != idx.end() && itr->author == author && itr->tag == tag )
+      {
+         _db.modify( *itr, [&]( author_tag_stats_object& stats )
+         {
             stats.total_posts++;
          });
-      } else {
-         _db.create<author_tag_stats_object>( [&]( author_tag_stats_object& stats ) {
+      }
+      else
+      {
+         _db.create<author_tag_stats_object>( [&]( author_tag_stats_object& stats )
+         {
             stats.author = author;
             stats.tag    = tag;
             stats.total_posts = 1;
@@ -301,13 +325,15 @@ struct operation_visitor {
       {
          update_tags( _db.get_comment( c.parent_author, c.parent_permlink ) );
       }
-   } FC_CAPTURE_LOG_AND_RETHROW( (c) )
-}
+      } FC_CAPTURE_LOG_AND_RETHROW( (c) )
+   }
 
-   const peer_stats_object& get_or_create_peer_stats( account_id_type voter, account_id_type peer )const {
+   const peer_stats_object& get_or_create_peer_stats( account_id_type voter, account_id_type peer )const
+   {
       const auto& peeridx = _db.get_index<peer_stats_index>().indices().get<by_voter_peer>();
       auto itr = peeridx.find( boost::make_tuple( voter, peer ) );
-      if( itr == peeridx.end() ) {
+      if( itr == peeridx.end() )
+      {
          return _db.create<peer_stats_object>( [&]( peer_stats_object& obj ) {
                obj.voter = voter;
                obj.peer  = peer;
@@ -315,73 +341,91 @@ struct operation_visitor {
       }
       return *itr;
    }
-   void update_indirect_vote( account_id_type a, account_id_type b, int positive )const {
-      if( a == b ) return;
+
+   void update_indirect_vote( account_id_type a, account_id_type b, int positive )const
+   {
+      if( a == b )
+         return;
       const auto& ab = get_or_create_peer_stats( a, b );
       const auto& ba = get_or_create_peer_stats( b, a );
-      _db.modify( ab, [&]( peer_stats_object& o ) {
-                  o.indirect_positive_votes += positive;
-                  o.indirect_votes++;
-                  o.update_rank();
-                  });
-      _db.modify( ba, [&]( peer_stats_object& o ) {
-                  o.indirect_positive_votes += positive;
-                  o.indirect_votes++;
-                  o.update_rank();
-                  });
+      _db.modify( ab, [&]( peer_stats_object& o )
+      {
+         o.indirect_positive_votes += positive;
+         o.indirect_votes++;
+         o.update_rank();
+      });
+      _db.modify( ba, [&]( peer_stats_object& o )
+      {
+         o.indirect_positive_votes += positive;
+         o.indirect_votes++;
+         o.update_rank();
+      });
    }
 
-   void update_peer_stats( const account_object& voter, const account_object& author, const comment_object& c, int vote )const {
+   void update_peer_stats( const account_object& voter, const account_object& author, const comment_object& c, int vote )const
+   {
       if( voter.id == author.id ) return; /// ignore votes for yourself
       if( c.parent_author.size() ) return; /// only count top level posts
 
       const auto& stat = get_or_create_peer_stats( voter.id, author.id );
-      _db.modify( stat, [&]( peer_stats_object& obj ) {
-            obj.direct_votes++;
-            obj.direct_positive_votes += vote > 0;
-            obj.update_rank();
+      _db.modify( stat, [&]( peer_stats_object& obj )
+      {
+         obj.direct_votes++;
+         obj.direct_positive_votes += vote > 0;
+         obj.update_rank();
       });
 
       const auto& voteidx = _db.get_index<comment_vote_index>().indices().get<by_comment_voter>();
       auto itr = voteidx.lower_bound( boost::make_tuple( comment_id_type(c.id), account_id_type() ) );
-      while( itr != voteidx.end() && itr->comment == c.id ) {
+      while( itr != voteidx.end() && itr->comment == c.id )
+      {
          update_indirect_vote( voter.id, itr->voter, (itr->vote_percent > 0)  == (vote > 0) );
          ++itr;
       }
    }
 
-   void operator()( const comment_operation& op )const {
+   void operator()( const comment_operation& op )const
+   {
       update_tags( _db.get_comment( op.author, op.permlink ), true );
    }
 
-   void operator()( const transfer_operation& op )const {
-      if( op.to == STEEMIT_NULL_ACCOUNT && op.amount.symbol == SBD_SYMBOL )  {
+   void operator()( const transfer_operation& op )const
+   {
+      if( op.to == STEEMIT_NULL_ACCOUNT && op.amount.symbol == SBD_SYMBOL )
+      {
          vector<string> part; part.reserve(4);
          auto path = op.memo;
          boost::split( part, path, boost::is_any_of("/") );
-         if( part[0].size() && part[0][0] == '@' ) {
+         if( part[0].size() && part[0][0] == '@' )
+         {
             auto acnt = part[0].substr(1);
             auto perm = part[1];
 
             auto c = _db.find_comment( acnt, perm );
-            if( c && c->parent_author.size() == 0 ) {
+            if( c && c->parent_author.size() == 0 )
+            {
                const auto& comment_idx = _db.get_index<tag_index>().indices().get<by_comment>();
                auto citr = comment_idx.lower_bound( c->id );
-               while( citr != comment_idx.end() && citr->comment == c->id ) {
-                  _db.modify( *citr, [&]( tag_object& t ) {
+               while( citr != comment_idx.end() && citr->comment == c->id )
+               {
+                  _db.modify( *citr, [&]( tag_object& t )
+                  {
                       if( t.cashout != fc::time_point_sec::maximum() )
                           t.promoted_balance += op.amount.amount;
                   });
                   ++citr;
                }
-            } else {
+            }
+            else
+            {
                ilog( "unable to find body" );
             }
          }
       }
    }
 
-   void operator()( const vote_operation& op )const {
+   void operator()( const vote_operation& op )const
+   {
       update_tags( _db.get_comment( op.author, op.permlink ) );
       /*
       update_peer_stats( _db.get_account(op.voter),
@@ -391,22 +435,26 @@ struct operation_visitor {
                          */
    }
 
-   void operator()( const delete_comment_operation& op )const {
+   void operator()( const delete_comment_operation& op )const
+   {
       const auto& idx = _db.get_index<tag_index>().indices().get<by_author_comment>();
 
       const auto& auth = _db.get_account(op.author);
       auto itr = idx.lower_bound( boost::make_tuple( auth.id ) );
-      while( itr != idx.end() && itr->author == auth.id ) {
+      while( itr != idx.end() && itr->author == auth.id )
+      {
          const auto& tobj = *itr;
          const auto* obj = _db.find< comment_object >( itr->comment );
          ++itr;
-         if( !obj ) {
+         if( !obj )
+         {
             _db.remove( tobj );
          }
       }
    }
 
-   void operator()( const comment_reward_operation& op )const {
+   void operator()( const comment_reward_operation& op )const
+   {
       const auto& c = _db.get_comment( op.author, op.permlink );
       update_tags( c );
 
@@ -421,7 +469,8 @@ struct operation_visitor {
       }
    }
 
-   void operator()( const comment_payout_update_operation& op )const {
+   void operator()( const comment_payout_update_operation& op )const
+   {
       const auto& c = _db.get_comment( op.author, op.permlink );
       update_tags( c );
    }

--- a/libraries/plugins/tags/tags_plugin.cpp
+++ b/libraries/plugins/tags/tags_plugin.cpp
@@ -116,11 +116,14 @@ struct operation_visitor {
          }
       }
 
+      // We need to write the transformed tags into a temporary
+      // local container because we can't modify meta.tags concurrently
+      // as we iterate over it.
       set< string > lower_tags;
 
       uint8_t tag_limit = 5;
       uint8_t count = 0;
-      for( const auto& tag : meta.tags )
+      for( const string& tag : meta.tags )
       {
          ++count;
          if( count > tag_limit || lower_tags.size() > tag_limit )
@@ -407,7 +410,7 @@ struct operation_visitor {
       const auto& c = _db.get_comment( op.author, op.permlink );
       update_tags( c );
 
-      auto meta = filter_tags( c );
+      comment_metadata meta = filter_tags( c );
 
       for( const string& tag : meta.tags )
       {


### PR DESCRIPTION
Further PR for #1161 `update_tags` changes.

I thought this was going to be a more substantial PR, but I realized partway through that the two minor optimizations I wanted to do (caching the result of `filter_tags` and replacing `lower_tags` with `meta.tags`) don't actually apply -- the former is rendered irrelevant and the latter isn't possible because it would result in concurrent modification.

So the most extreme change in this PR ended up being changing an iterate-by-value to iterate-by-reference :)