### PR TITLE
Update brew syntax due to change in handling versions

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -162,7 +162,6 @@ Install Homebrew by following the instructions here: http://brew.sh/
 
    brew doctor
    brew update
-   brew tap homebrew/versions
 
 ### Install steem dependencies:
 
@@ -171,7 +170,7 @@ Install Homebrew by following the instructions here: http://brew.sh/
         automake \
         cmake \
         git \
-        homebrew/versions/boost160 \
+        boost160 \
         libtool \
         openssl \
         python3
@@ -196,7 +195,7 @@ steem. Until then, this will allow you to install boost 1.60.0.
 ### Compile
 
     export OPENSSL_ROOT_DIR=$(brew --prefix)/Cellar/openssl/1.0.2h_1/
-    export BOOST_ROOT=$(brew --prefix)/Cellar/boost160/1.60.0/
+    export BOOST_ROOT=$(brew --prefix)/Cellar/boost@1.60/1.60.0/
     git submodule update --init --recursive
     mkdir build && cd build
     cmake -DBOOST_ROOT="$BOOST_ROOT" -DCMAKE_BUILD_TYPE=Release ..


### PR DESCRIPTION
Homebrew changed the way they handle versions and eliminated the versions sub-tree.  Also changed the pathnames in the Cellar for legacy versions.

Encountered this while setting up a miner and steemd kept crashing after compile.  Updated build instructions to reflect the correct syntax for building under OS X/MacOS.