### PR TITLE
Fix denominator in vote_evaluator computation #1285

### DIFF
--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -1168,24 +1168,34 @@ void vote_evaluator::do_apply( const vote_operation& o )
 
    int64_t  abs_weight    = abs(o.weight);
    int64_t  used_power    = (current_power * abs_weight) / STEEMIT_100_PERCENT;
+   // Less rounding error would occur if we did the division last, but we need to maintain backward
+   // compatibility with the previous implementation which was replaced in #1285
+   int64_t  used_power_2  = ((current_power * abs_weight) / STEEMIT_100_PERCENT) * (60*60*24);
 
    const dynamic_global_property_object& dgpo = _db.get_dynamic_global_properties();
 
    // used_power = (current_power * abs_weight / STEEMIT_100_PERCENT) * (reserve / max_vote_denom)
    // The second multiplication is rounded up as of HF 259
    int64_t max_vote_denom = dgpo.vote_power_reserve_rate * STEEMIT_VOTE_REGENERATION_SECONDS / (60*60*24);
+   int64_t max_vote_denom_2 = dgpo.vote_power_reserve_rate * STEEMIT_VOTE_REGENERATION_SECONDS;
    FC_ASSERT( max_vote_denom > 0 );
 
    if( !_db.has_hardfork( STEEMIT_HARDFORK_0_14__259 ) )
    {
       FC_ASSERT( max_vote_denom == 200 );   // TODO: Remove this assert
       used_power = (used_power / max_vote_denom)+1;
+      used_power_2 = (used_power_2 / max_vote_denom_2)+1;
    }
    else
    {
       used_power = (used_power + max_vote_denom - 1) / max_vote_denom;
+      used_power_2 = (used_power_2 + max_vote_denom_2 - 1) / max_vote_denom_2;
    }
    FC_ASSERT( used_power <= current_power, "Account does not have enough power to vote." );
+   if( used_power != used_power_2 )
+   {
+      elog( "used_power=${up}, used_power_2=${up2} at block ${bid}", ("up", used_power)("up2", used_power_2)("bid", _db.head_block_id()) );
+   }
 
    int64_t abs_rshares    = ((uint128_t(voter.effective_vesting_shares().amount.value) * used_power) / (STEEMIT_100_PERCENT)).to_uint64();
    if( !_db.has_hardfork( STEEMIT_HARDFORK_0_14__259 ) && abs_rshares == 0 ) abs_rshares = 1;

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -1167,35 +1167,25 @@ void vote_evaluator::do_apply( const vote_operation& o )
    FC_ASSERT( current_power > 0, "Account currently does not have voting power." );
 
    int64_t  abs_weight    = abs(o.weight);
-   int64_t  used_power    = (current_power * abs_weight) / STEEMIT_100_PERCENT;
    // Less rounding error would occur if we did the division last, but we need to maintain backward
    // compatibility with the previous implementation which was replaced in #1285
-   int64_t  used_power_2  = ((current_power * abs_weight) / STEEMIT_100_PERCENT) * (60*60*24);
+   int64_t  used_power  = ((current_power * abs_weight) / STEEMIT_100_PERCENT) * (60*60*24);
 
    const dynamic_global_property_object& dgpo = _db.get_dynamic_global_properties();
 
-   // used_power = (current_power * abs_weight / STEEMIT_100_PERCENT) * (reserve / max_vote_denom)
    // The second multiplication is rounded up as of HF 259
-   int64_t max_vote_denom = dgpo.vote_power_reserve_rate * STEEMIT_VOTE_REGENERATION_SECONDS / (60*60*24);
-   int64_t max_vote_denom_2 = dgpo.vote_power_reserve_rate * STEEMIT_VOTE_REGENERATION_SECONDS;
+   int64_t max_vote_denom = dgpo.vote_power_reserve_rate * STEEMIT_VOTE_REGENERATION_SECONDS;
    FC_ASSERT( max_vote_denom > 0 );
 
    if( !_db.has_hardfork( STEEMIT_HARDFORK_0_14__259 ) )
    {
-      FC_ASSERT( max_vote_denom == 200 );   // TODO: Remove this assert
       used_power = (used_power / max_vote_denom)+1;
-      used_power_2 = (used_power_2 / max_vote_denom_2)+1;
    }
    else
    {
       used_power = (used_power + max_vote_denom - 1) / max_vote_denom;
-      used_power_2 = (used_power_2 + max_vote_denom_2 - 1) / max_vote_denom_2;
    }
    FC_ASSERT( used_power <= current_power, "Account does not have enough power to vote." );
-   if( used_power != used_power_2 )
-   {
-      elog( "used_power=${up}, used_power_2=${up2} at block ${bid}", ("up", used_power)("up2", used_power_2)("bid", _db.head_block_id()) );
-   }
 
    int64_t abs_rshares    = ((uint128_t(voter.effective_vesting_shares().amount.value) * used_power) / (STEEMIT_100_PERCENT)).to_uint64();
    if( !_db.has_hardfork( STEEMIT_HARDFORK_0_14__259 ) && abs_rshares == 0 ) abs_rshares = 1;


### PR DESCRIPTION
Guide to review:

- The first commit does the new computation but throws away the result, except for printing a message when it does not match the old computation.
- The second commit throws away the old computation and only does the new computation.

If we replay the blockchain with the first commit only, and verify that the message is not printed, then the PR is valid and ready to merge.  I'm currently replaying and verifying this.
