### PR TITLE
Issue 1308, eliminate static_casts from appbase::plugin

### DIFF
--- a/libraries/appbase/examples/main.cpp
+++ b/libraries/appbase/examples/main.cpp
@@ -30,9 +30,19 @@ class plugin_a : public appbase::plugin<plugin_a>
                ;
      }
 
-     void plugin_initialize( const variables_map& options ) { std::cout << "initialize plugin_a plugin\n"; }
-     void plugin_startup()  { std::cout << "starting plugin_a plugin \n"; }
-     void plugin_shutdown() { std::cout << "shutdown plugin_a plugin \n"; }
+    virtual void plugin_initialize( const variables_map& options ) override
+    {
+        std::cout << "initialize plugin_a plugin\n";
+    }
+    virtual void plugin_startup() override
+    {
+       std::cout << "starting plugin_a plugin \n";
+    }
+    
+    virtual void plugin_shutdown() override
+    {
+      std::cout << "shutdown plugin_a plugin \n";
+    }
 
      database& db() { return _db; }
 
@@ -59,9 +69,21 @@ class plugin_b : public appbase::plugin<plugin_b>
               ;
      }
 
-     void plugin_initialize( const variables_map& options ) { std::cout << "initialize plugin_b plugin\n"; }
-     void plugin_startup()  { std::cout << "starting plugin_b plugin \n"; }
-     void plugin_shutdown() { std::cout << "shutdown plugin_b plugin \n"; }
+    protected:
+      virtual void plugin_initialize( const variables_map& options ) override
+      {
+      std::cout << "initialize plugin_b plugin\n";
+      }
+     
+      virtual void plugin_startup() override
+      {
+         std::cout << "starting plugin_b plugin \n";
+      }
+
+      virtual void plugin_shutdown() override
+      {
+         std::cout << "shutdown plugin_b plugin \n";
+      }
 
 };
 

--- a/libraries/appbase/include/appbase/application.hpp
+++ b/libraries/appbase/include/appbase/application.hpp
@@ -117,51 +117,51 @@ namespace appbase {
       public:
          virtual ~plugin() {}
 
-         virtual state get_state()const override { return _state; }
+         virtual state get_state() const override { return _state; }
          virtual const std::string& get_name()const override final { return Impl::name(); }
 
          virtual void register_dependencies()
          {
-            static_cast< Impl* >( this )->plugin_requires( [&]( auto& plug ){} );
+            this->plugin_requires( [&]( abstract_plugin& plug ){} );
          }
 
-         virtual void initialize(const variables_map& options) override
+         virtual void initialize(const variables_map& options) override final
          {
             if( _state == registered )
             {
                _state = initialized;
-               static_cast< Impl* >( this )->plugin_requires( [&]( auto& plug ){ plug.initialize( options ); } );
-               static_cast< Impl* >( this )->plugin_initialize( options );
+               this->plugin_requires( [&]( abstract_plugin& plug ){ plug.initialize( options ); } );
+               this->plugin_initialize( options );
                // std::cout << "initializing plugin " << name() << std::endl;
                app().plugin_initialized( *this );
             }
             assert( _state == initialized ); /// if initial state was not registered, final state cannot be initiaized
          }
 
-         virtual void startup() override
+         virtual void startup() override final
          {
             if( _state == initialized )
             {
                _state = started;
-               static_cast< Impl* >( this )->plugin_requires( [&]( auto& plug ){ plug.startup(); } );
-               static_cast< Impl* >( this )->plugin_startup();
+               this->plugin_requires( [&]( abstract_plugin& plug ){ plug.startup(); } );
+               this->plugin_startup();
                app().plugin_started( *this );
             }
             assert( _state == started ); // if initial state was not initialized, final state cannot be started
          }
 
-         virtual void shutdown() override
+         virtual void shutdown() override final
          {
             if( _state == started )
             {
                _state = stopped;
                //ilog( "shutting down plugin ${name}", ("name",name()) );
-               static_cast< Impl* >( this )->plugin_shutdown();
+               this->plugin_shutdown();
             }
          }
 
       protected:
-         plugin() {}
+         plugin() = default;
 
       private:
          state _state = abstract_plugin::registered;

--- a/libraries/plugins/account_by_key/include/steemit/plugins/account_by_key/account_by_key_plugin.hpp
+++ b/libraries/plugins/account_by_key/include/steemit/plugins/account_by_key/account_by_key_plugin.hpp
@@ -20,9 +20,9 @@ class account_by_key_plugin : public appbase::plugin< account_by_key_plugin >
       static const std::string& name() { static std::string name = STEEM_ACCOUNT_BY_KEY_PLUGIN_NAME; return name; }
 
       virtual void set_program_options( options_description& cli, options_description& cfg ) override;
-      void plugin_initialize( const variables_map& options );
-      void plugin_startup();
-      void plugin_shutdown();
+      virtual void plugin_initialize( const variables_map& options ) override;
+      virtual void plugin_startup() override;
+      virtual void plugin_shutdown() override;
 
       std::unique_ptr< class account_by_key_plugin_impl > my;
 };

--- a/libraries/plugins/account_history/include/steemit/plugins/account_history/account_history_plugin.hpp
+++ b/libraries/plugins/account_history/include/steemit/plugins/account_history/account_history_plugin.hpp
@@ -59,12 +59,12 @@ class account_history_plugin : public plugin< account_history_plugin >
 
       static const std::string& name() { static std::string name = STEEM_ACCOUNT_HISTORY_PLUGIN_NAME; return name; }
 
-      void set_program_options(
+      virtual void set_program_options(
          options_description& cli,
-         options_description& cfg );
-      void plugin_initialize( const variables_map& options );
-      void plugin_startup();
-      void plugin_shutdown();
+         options_description& cfg ) override;
+      virtual void plugin_initialize( const variables_map& options ) override;
+      virtual void plugin_startup() override;
+      virtual void plugin_shutdown() override;
 
       flat_map< account_name_type, account_name_type > tracked_accounts()const; /// map start_range to end_range
 

--- a/libraries/plugins/apis/account_by_key_api/include/steemit/plugins/account_by_key_api/account_by_key_api_plugin.hpp
+++ b/libraries/plugins/apis/account_by_key_api/include/steemit/plugins/account_by_key_api/account_by_key_api_plugin.hpp
@@ -26,9 +26,9 @@ public:
 
    virtual void set_program_options( options_description& cli, options_description& cfg ) override;
 
-   void plugin_initialize( const variables_map& options );
-   void plugin_startup();
-   void plugin_shutdown();
+   virtual void plugin_initialize( const variables_map& options ) override;
+   virtual void plugin_startup() override;
+   virtual void plugin_shutdown() override;
 
    std::shared_ptr< class account_by_key_api > api;
 };

--- a/libraries/plugins/apis/account_history_api/include/steemit/plugins/account_history_api/account_history_api_plugin.hpp
+++ b/libraries/plugins/apis/account_history_api/include/steemit/plugins/account_history_api/account_history_api_plugin.hpp
@@ -26,9 +26,9 @@ public:
 
    virtual void set_program_options( options_description& cli, options_description& cfg ) override;
 
-   void plugin_initialize( const variables_map& options );
-   void plugin_startup();
-   void plugin_shutdown();
+   virtual void plugin_initialize( const variables_map& options ) override;
+   virtual void plugin_startup() override;
+   virtual void plugin_shutdown() override;
 
    std::shared_ptr< class account_history_api > api;
 };

--- a/libraries/plugins/apis/condenser_api/include/steemit/plugins/condenser_api/condenser_api_plugin.hpp
+++ b/libraries/plugins/apis/condenser_api/include/steemit/plugins/condenser_api/condenser_api_plugin.hpp
@@ -20,9 +20,9 @@ public:
 
    virtual void set_program_options( options_description& cli, options_description& cfg ) override;
 
-   void plugin_initialize( const variables_map& options );
-   void plugin_startup();
-   void plugin_shutdown();
+   virtual void plugin_initialize( const variables_map& options ) override;
+   virtual void plugin_startup() override;
+   virtual void plugin_shutdown() override;
 
    std::shared_ptr< class condenser_api > api;
 };

--- a/libraries/plugins/apis/database_api/include/steemit/plugins/database_api/database_api_plugin.hpp
+++ b/libraries/plugins/apis/database_api/include/steemit/plugins/database_api/database_api_plugin.hpp
@@ -26,9 +26,9 @@ class database_api_plugin : public plugin< database_api_plugin >
       virtual void set_program_options(
          options_description& cli,
          options_description& cfg ) override;
-      void plugin_initialize( const variables_map& options );
-      void plugin_startup();
-      void plugin_shutdown();
+      virtual void plugin_initialize( const variables_map& options ) override;
+      virtual void plugin_startup() override;
+      virtual void plugin_shutdown() override;
 
       std::shared_ptr< class database_api > api;
 };

--- a/libraries/plugins/apis/debug_node_api/include/steemit/plugins/debug_node_api/debug_node_api_plugin.hpp
+++ b/libraries/plugins/apis/debug_node_api/include/steemit/plugins/debug_node_api/debug_node_api_plugin.hpp
@@ -26,9 +26,9 @@ public:
 
    virtual void set_program_options( options_description& cli, options_description& cfg ) override;
 
-   void plugin_initialize( const variables_map& options );
-   void plugin_startup();
-   void plugin_shutdown();
+   virtual void plugin_initialize( const variables_map& options ) override;
+   virtual void plugin_startup() override;
+   virtual void plugin_shutdown() override;
 
    std::shared_ptr< class debug_node_api > api;
 };

--- a/libraries/plugins/apis/follow_api/include/steemit/plugins/follow_api/follow_api_plugin.hpp
+++ b/libraries/plugins/apis/follow_api/include/steemit/plugins/follow_api/follow_api_plugin.hpp
@@ -26,9 +26,9 @@ public:
 
    virtual void set_program_options( options_description& cli, options_description& cfg ) override;
 
-   void plugin_initialize( const variables_map& options );
-   void plugin_startup();
-   void plugin_shutdown();
+   virtual void plugin_initialize( const variables_map& options ) override;
+   virtual void plugin_startup() override;
+   virtual void plugin_shutdown() override;
 
    std::shared_ptr< class follow_api > api;
 };

--- a/libraries/plugins/apis/market_history_api/include/steemit/plugins/market_history_api/market_history_api_plugin.hpp
+++ b/libraries/plugins/apis/market_history_api/include/steemit/plugins/market_history_api/market_history_api_plugin.hpp
@@ -26,9 +26,9 @@ public:
 
    virtual void set_program_options( options_description& cli, options_description& cfg ) override;
 
-   void plugin_initialize( const variables_map& options );
-   void plugin_startup();
-   void plugin_shutdown();
+   virtual void plugin_initialize( const variables_map& options ) override;
+   virtual void plugin_startup() override;
+   virtual void plugin_shutdown() override;
 
    std::shared_ptr< class market_history_api > api;
 };

--- a/libraries/plugins/apis/network_broadcast_api/include/steemit/plugins/network_broadcast_api/network_broadcast_api_plugin.hpp
+++ b/libraries/plugins/apis/network_broadcast_api/include/steemit/plugins/network_broadcast_api/network_broadcast_api_plugin.hpp
@@ -26,9 +26,9 @@ public:
    static const std::string& name() { static std::string name = STEEM_NETWORK_BROADCAST_API_PLUGIN_NAME; return name; }
 
    virtual void set_program_options( options_description& cli, options_description& cfg ) override;
-   void plugin_initialize( const variables_map& options );
-   void plugin_startup();
-   void plugin_shutdown();
+   virtual void plugin_initialize( const variables_map& options ) override;
+   virtual void plugin_startup() override;
+   virtual void plugin_shutdown() override;
 
    std::shared_ptr< class network_broadcast_api > api;
 };

--- a/libraries/plugins/apis/tags_api/include/steemit/plugins/tags_api/tags_api_plugin.hpp
+++ b/libraries/plugins/apis/tags_api/include/steemit/plugins/tags_api/tags_api_plugin.hpp
@@ -26,9 +26,9 @@ public:
 
    virtual void set_program_options( options_description& cli, options_description& cfg ) override;
 
-   void plugin_initialize( const variables_map& options );
-   void plugin_startup();
-   void plugin_shutdown();
+   virtual void plugin_initialize( const variables_map& options ) override;
+   virtual void plugin_startup() override;
+   virtual void plugin_shutdown() override;
 
    std::shared_ptr< class tags_api > api;
 };

--- a/libraries/plugins/apis/test_api/include/steemit/plugins/test_api/test_api_plugin.hpp
+++ b/libraries/plugins/apis/test_api/include/steemit/plugins/test_api/test_api_plugin.hpp
@@ -27,9 +27,9 @@ class test_api_plugin : public appbase::plugin< test_api_plugin >
 
       virtual void set_program_options( options_description&, options_description& ) override {}
 
-      void plugin_initialize( const variables_map& options );
-      void plugin_startup();
-      void plugin_shutdown();
+      virtual void plugin_initialize( const variables_map& options ) override;
+      virtual void plugin_startup() override;
+      virtual void plugin_shutdown() override;
 
       string test_api_a( const test_api_a_args& args ) { return "A"; }
       string test_api_b( const test_api_b_args& args ) { return "B"; }

--- a/libraries/plugins/apis/witness_api/include/steemit/plugins/witness_api/witness_api_plugin.hpp
+++ b/libraries/plugins/apis/witness_api/include/steemit/plugins/witness_api/witness_api_plugin.hpp
@@ -26,9 +26,9 @@ public:
 
    virtual void set_program_options( options_description& cli, options_description& cfg ) override;
 
-   void plugin_initialize( const variables_map& options );
-   void plugin_startup();
-   void plugin_shutdown();
+   virtual void plugin_initialize( const variables_map& options ) override;
+   virtual void plugin_startup() override;
+   virtual void plugin_shutdown() override;
 
    std::shared_ptr< class witness_api > api;
 };

--- a/libraries/plugins/chain/include/steemit/plugins/chain/chain_plugin.hpp
+++ b/libraries/plugins/chain/include/steemit/plugins/chain/chain_plugin.hpp
@@ -21,9 +21,9 @@ public:
    static const std::string& name() { static std::string name = STEEM_CHAIN_PLUGIN_NAME; return name; }
 
    virtual void set_program_options( options_description& cli, options_description& cfg ) override;
-   void plugin_initialize( const variables_map& options );
-   void plugin_startup();
-   void plugin_shutdown();
+   virtual void plugin_initialize( const variables_map& options ) override;
+   virtual void plugin_startup() override;
+   virtual void plugin_shutdown() override;
 
    bool accept_block( const steemit::chain::signed_block& block, bool currently_syncing );
    void accept_transaction( const steemit::chain::signed_transaction& trx );

--- a/libraries/plugins/debug_node/include/steemit/plugins/debug_node/debug_node_plugin.hpp
+++ b/libraries/plugins/debug_node/include/steemit/plugins/debug_node/debug_node_plugin.hpp
@@ -46,9 +46,9 @@ class debug_node_plugin : public plugin< debug_node_plugin >
       virtual void set_program_options(
          options_description& cli,
          options_description& cfg ) override;
-      void plugin_initialize( const variables_map& options );
-      void plugin_startup();
-      void plugin_shutdown();
+      virtual void plugin_initialize( const variables_map& options ) override;
+      virtual void plugin_startup() override;
+      virtual void plugin_shutdown() override;
 
       chain::database& database();
 

--- a/libraries/plugins/follow/include/steemit/plugins/follow/follow_plugin.hpp
+++ b/libraries/plugins/follow/include/steemit/plugins/follow/follow_plugin.hpp
@@ -24,12 +24,12 @@ class follow_plugin : public appbase::plugin< follow_plugin >
 
       static const std::string& name() { static std::string name = STEEM_FOLLOW_PLUGIN_NAME; return name; }
 
-      void set_program_options(
+      virtual void set_program_options(
          options_description& cli,
-         options_description& cfg );
-      void plugin_initialize( const variables_map& options );
-      void plugin_startup();
-      void plugin_shutdown();
+         options_description& cfg ) override;
+      virtual void plugin_initialize( const variables_map& options ) override;
+      virtual void plugin_startup() override;
+      virtual void plugin_shutdown() override;
 
       uint32_t max_feed_size = 500;
       fc::time_point_sec start_feeds;

--- a/libraries/plugins/json_rpc/include/steemit/plugins/json_rpc/json_rpc_plugin.hpp
+++ b/libraries/plugins/json_rpc/include/steemit/plugins/json_rpc/json_rpc_plugin.hpp
@@ -90,9 +90,9 @@ class json_rpc_plugin : public appbase::plugin< json_rpc_plugin >
 
       static const std::string& name() { static std::string name = STEEM_JSON_RPC_PLUGIN_NAME; return name; }
 
-      void plugin_initialize( const variables_map& options );
-      void plugin_startup();
-      void plugin_shutdown();
+      virtual void plugin_initialize( const variables_map& options ) override;
+      virtual void plugin_startup() override;
+      virtual void plugin_shutdown() override;
 
       void add_api_method( const string& api_name, const string& method_name, const api_method& api );
       string call( const string& body );

--- a/libraries/plugins/market_history/include/steemit/plugins/market_history/market_history_plugin.hpp
+++ b/libraries/plugins/market_history/include/steemit/plugins/market_history/market_history_plugin.hpp
@@ -47,15 +47,17 @@ class market_history_plugin : public plugin< market_history_plugin >
 
       static const std::string& name() { static std::string name = STEEM_MARKET_HISTORY_PLUGIN_NAME; return name; }
 
-      virtual void set_program_options(
-         options_description& cli,
-         options_description& cfg );
-      void plugin_initialize( const variables_map& options );
-      void plugin_startup();
-      void plugin_shutdown();
-
       flat_set< uint32_t > get_tracked_buckets() const;
       uint32_t get_max_history_per_bucket() const;
+
+      virtual void set_program_options(
+         options_description& cli,
+         options_description& cfg ) override;
+
+   protected:
+      virtual void plugin_initialize( const variables_map& options ) override;
+      virtual void plugin_startup() override;
+      virtual void plugin_shutdown() override;
 
    private:
       friend class detail::market_history_plugin_impl;

--- a/libraries/plugins/p2p/include/steemit/plugins/p2p/p2p_plugin.hpp
+++ b/libraries/plugins/p2p/include/steemit/plugins/p2p/p2p_plugin.hpp
@@ -44,9 +44,9 @@ public:
 
    static const std::string& name() { static std::string name = STEEM_P2P_PLUGIN_NAME; return name; }
 
-   virtual void plugin_initialize(const bpo::variables_map& options);
-   virtual void plugin_startup();
-   virtual void plugin_shutdown();
+   virtual void plugin_initialize(const bpo::variables_map& options) override;
+   virtual void plugin_startup() override;
+   virtual void plugin_shutdown() override;
 
    void broadcast_block( const steemit::protocol::signed_block& block );
    void broadcast_transaction( const steemit::protocol::signed_transaction& tx );

--- a/libraries/plugins/tags/include/steemit/plugins/tags/tags_plugin.hpp
+++ b/libraries/plugins/tags/include/steemit/plugins/tags/tags_plugin.hpp
@@ -474,10 +474,10 @@ class tags_plugin : public plugin< tags_plugin >
 
       virtual void set_program_options(
          options_description& cli,
-         options_description& cfg);
-      void plugin_initialize( const variables_map& options );
-      void plugin_startup();
-      void plugin_shutdown();
+         options_description& cfg) override;
+      virtual void plugin_initialize( const variables_map& options ) override;
+      virtual void plugin_startup() override;
+      virtual void plugin_shutdown() override;
 
       friend class detail::tags_plugin_impl;
       std::unique_ptr< detail::tags_plugin_impl > my;

--- a/libraries/plugins/webserver/include/steemit/plugins/webserver/webserver_plugin.hpp
+++ b/libraries/plugins/webserver/include/steemit/plugins/webserver/webserver_plugin.hpp
@@ -37,9 +37,10 @@ class webserver_plugin : public appbase::plugin< webserver_plugin >
 
       virtual void set_program_options(options_description&, options_description& cfg) override;
 
-      void plugin_initialize(const variables_map& options);
-      void plugin_startup();
-      void plugin_shutdown();
+   protected:
+      virtual void plugin_initialize(const variables_map& options) override;
+      virtual void plugin_startup() override;
+      virtual void plugin_shutdown() override;
 
    private:
       std::unique_ptr< class webserver_plugin_impl > _my;

--- a/libraries/plugins/witness/include/steemit/plugins/witness/witness_plugin.hpp
+++ b/libraries/plugins/witness/include/steemit/plugins/witness/witness_plugin.hpp
@@ -69,9 +69,9 @@ public:
       boost::program_options::options_description &config_file_options
       ) override;
 
-   virtual void plugin_initialize(const boost::program_options::variables_map& options);
-   virtual void plugin_startup();
-   virtual void plugin_shutdown();
+   virtual void plugin_initialize(const boost::program_options::variables_map& options) override;
+   virtual void plugin_startup() override;
+   virtual void plugin_shutdown() override;
 
 private:
    std::unique_ptr< detail::witness_plugin_impl > my;


### PR DESCRIPTION
Introduced new protected virt. methods to be reimplemented in plugin implementation: plugin_initialize, plugin_startup, plugin_shutdown, plugin_requires earlied being just provided by implementation via template argument.