### PR TITLE
Use STEEMIT_INIT_SUPPLY when reindexing

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -150,7 +150,7 @@ void database::reindex( const fc::path& data_dir, const fc::path& shared_mem_dir
    {
       ilog( "Reindexing Blockchain" );
       wipe( data_dir, shared_mem_dir, false );
-      open( data_dir, shared_mem_dir, 0, shared_file_size, chainbase::database::read_write );
+      open( data_dir, shared_mem_dir, STEEMIT_INIT_SUPPLY, shared_file_size, chainbase::database::read_write );
       _fork_db.reset();    // override effect of _fork_db.start_block() call in open()
 
       auto start = fc::time_point::now();


### PR DESCRIPTION
This fixes a bug where a chain with a non-zero `STEEMIT_INIT_SUPPLY` would be unable to run a `--rebuild` if spending any of the `STEEMIT_INIT_SUPPLY`.

Refs #1225 