### PR TITLE
Make build dir read-only before running tests #1562

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN \
         -DSKIP_BY_TX_ID=ON \
         .. && \
     make -j$(nproc) chain_test test_fixed_string plugin_test && \
+    cd .. && chmod -R a-w build && cd build && \
     ./tests/chain_test && \
     ./programs/util/test_fixed_string && \
     cd /usr/local/src/steem && \
@@ -75,6 +76,7 @@ RUN \
         -DENABLE_SMT_SUPPORT=ON \
         .. && \
     make -j$(nproc) chain_test test_fixed_string plugin_test && \
+    cd .. && chmod -R a-w build && cd build && \
     ./tests/chain_test && \
     ./programs/util/test_fixed_string && \
     cd /usr/local/src/steem && \
@@ -98,6 +100,7 @@ RUN \
         -DCHAINBASE_CHECK_LOCKING=OFF \
         .. && \
     make -j$(nproc) chain_test plugin_test && \
+    cd .. && chmod -R a-w build && cd build && \
     ./tests/chain_test && \
     mkdir -p /var/cobertura && \
     gcovr --object-directory="../" --root=../ --xml-pretty --gcov-exclude=".*tests.*" --gcov-exclude=".*fc.*" --gcov-exclude=".*app*" --gcov-exclude=".*net*" --gcov-exclude=".*plugins*" --gcov-exclude=".*schema*" --gcov-exclude=".*time*" --gcov-exclude=".*utilities*" --gcov-exclude=".*wallet*" --gcov-exclude=".*programs*" --output="/var/cobertura/coverage.xml" && \


### PR DESCRIPTION
PR for #1562.  This should not pass CI until a fix for #1561 is available, and should not be merged until it passes CI.

When such a fix is available, rebase this PR on the fix.  Then if CI passes for the rebased PR, the fix is valid, and both #1561 and #1562 can be closed once the rebased PR is merged to `develop`.
