### PR TITLE
Internal references to SMTs switched to asset symbol type

### DIFF
--- a/libraries/chain/include/steem/chain/smt_objects/smt_token_object.hpp
+++ b/libraries/chain/include/steem/chain/smt_objects/smt_token_object.hpp
@@ -25,11 +25,6 @@ public:
       c( *this );
    }
 
-   uint32_t get_nai() const
-   {
-      return symbol.to_nai();
-   }
-   
    // id_type is actually oid<smt_token_object>
    id_type           id;
 
@@ -69,7 +64,7 @@ public:
    uint8_t              rel_amount_denom_bits = 0;
 };
 
-struct by_nai;
+struct by_symbol;
 struct by_control_account;
 
 typedef multi_index_container <
@@ -77,8 +72,8 @@ typedef multi_index_container <
    indexed_by <
       ordered_unique< tag< by_id >,
          member< smt_token_object, smt_token_id_type, &smt_token_object::id > >,
-      ordered_unique< tag< by_nai >,
-         const_mem_fun< smt_token_object, uint32_t, &smt_token_object::get_nai > >,
+      ordered_unique< tag< by_symbol >,
+         member< smt_token_object, asset_symbol_type, &smt_token_object::symbol > >,
       ordered_non_unique< tag< by_control_account >,
          member< smt_token_object, account_name_type, &smt_token_object::control_account > >
    >,

--- a/libraries/chain/smt_evaluator.cpp
+++ b/libraries/chain/smt_evaluator.cpp
@@ -36,11 +36,11 @@ private:
 };
 
 const smt_token_object& common_pre_setup_evaluation(
-   const database& _db, const uint32_t& nai, const account_name_type& control_account )
+   const database& _db, const asset_symbol_type& symbol, const account_name_type& control_account )
 {
-   const smt_token_object* smt = _db.find< smt_token_object, by_nai >( nai );
+   const smt_token_object* smt = _db.find< smt_token_object, by_symbol >( symbol );
    // Check whether it's not too early to setup operation.
-   FC_ASSERT( smt != nullptr, "SMT numerical asset identifier ${smt} not found", ("smt", nai) );
+   FC_ASSERT( smt != nullptr, "SMT numerical asset identifier ${smt} not found", ("smt", symbol.to_nai()) );
    // Check whether some impostor tries to hijack SMT operation.
    FC_ASSERT( smt->control_account == control_account );
    // Check whether it's not too late to setup emissions operation.
@@ -120,7 +120,7 @@ void smt_setup_emissions_evaluator::do_apply( const smt_setup_emissions_operatio
 {
    FC_ASSERT( _db.has_hardfork( STEEM_SMT_HARDFORK ), "SMT functionality not enabled until hardfork ${hf}", ("hf", STEEM_SMT_HARDFORK) );
 
-   const smt_token_object& smt = common_pre_setup_evaluation(_db, o.nai, o.control_account);
+   const smt_token_object& smt = common_pre_setup_evaluation(_db, o.symbol, o.control_account);
 
    FC_ASSERT( o.lep_abs_amount.symbol == smt.symbol );
    // ^ Note that rep_abs_amount.symbol has been matched to lep's in validate().
@@ -145,7 +145,7 @@ void smt_set_setup_parameters_evaluator::do_apply( const smt_set_setup_parameter
 {
    FC_ASSERT( _db.has_hardfork( STEEM_SMT_HARDFORK ), "SMT functionality not enabled until hardfork ${hf}", ("hf", STEEM_SMT_HARDFORK) );
 
-   const smt_token_object& smt_token = common_pre_setup_evaluation(_db, o.nai, o.control_account);
+   const smt_token_object& smt_token = common_pre_setup_evaluation(_db, o.symbol, o.control_account);
    
    _db.modify( smt_token, [&]( smt_token_object& token )
    {
@@ -200,7 +200,7 @@ void smt_set_runtime_parameters_evaluator::do_apply( const smt_set_runtime_param
 {
    FC_ASSERT( _db.has_hardfork( STEEM_SMT_HARDFORK ), "SMT functionality not enabled until hardfork ${hf}", ("hf", STEEM_SMT_HARDFORK) );
 
-   const smt_token_object& _token = common_pre_setup_evaluation(_db, o.nai, o.control_account);
+   const smt_token_object& _token = common_pre_setup_evaluation(_db, o.symbol, o.control_account);
 
    smt_set_runtime_parameters_evaluator_visitor visitor( _token, _db );
 

--- a/libraries/protocol/include/steem/protocol/smt_operations.hpp
+++ b/libraries/protocol/include/steem/protocol/smt_operations.hpp
@@ -170,8 +170,8 @@ struct smt_emissions_unit
 
 struct smt_setup_emissions_operation : public base_operation
 {
-   /// Contains Numerical Asset Identifier (NAI) of the SMT.
-   uint32_t            nai;
+   /// Contains both Numerical Asset Identifier (NAI) and precision of the SMT.
+   asset_symbol_type   symbol;
    account_name_type   control_account;
 
    time_point_sec      schedule_time;
@@ -242,8 +242,8 @@ typedef static_variant<
 
 struct smt_set_setup_parameters_operation : public base_operation
 {
-   /// Contains Numerical Asset Identifier (NAI) of the SMT.
-   uint32_t                                          nai;
+   /// Contains both Numerical Asset Identifier (NAI) and precision of the SMT.
+   asset_symbol_type                                 symbol;
    account_name_type                                 control_account;
 
    flat_set< smt_setup_parameter >                   setup_parameters;
@@ -256,8 +256,8 @@ struct smt_set_setup_parameters_operation : public base_operation
 
 struct smt_set_runtime_parameters_operation : public base_operation
 {
-   /// Contains Numerical Asset Identifier (NAI) of the SMT.
-   uint32_t                                          nai;
+   /// Contains both Numerical Asset Identifier (NAI) and precision of the SMT.
+   asset_symbol_type                                 symbol;
    account_name_type                                 control_account;
 
    flat_set< smt_runtime_parameter >                 runtime_parameters;
@@ -344,7 +344,7 @@ FC_REFLECT(
 
 FC_REFLECT(
    steem::protocol::smt_setup_emissions_operation,
-   (nai)
+   (symbol)
    (control_account)
    (schedule_time)
    (emissions_unit)
@@ -399,7 +399,7 @@ FC_REFLECT_TYPENAME(
 
 FC_REFLECT(
    steem::protocol::smt_set_setup_parameters_operation,
-   (nai)
+   (symbol)
    (control_account)
    (setup_parameters)
    (extensions)
@@ -407,7 +407,7 @@ FC_REFLECT(
 
 FC_REFLECT(
    steem::protocol::smt_set_runtime_parameters_operation,
-   (nai)
+   (symbol)
    (control_account)
    (runtime_parameters)
    (extensions)

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -575,7 +575,7 @@ smt_database_fixture::~smt_database_fixture()
 
 }
 
-uint32_t smt_database_fixture::create_smt( signed_transaction& tx, const string& account_name, const fc::ecc::private_key& key,
+asset_symbol_type smt_database_fixture::create_smt( signed_transaction& tx, const string& account_name, const fc::ecc::private_key& key,
    uint8_t token_decimal_places )
 {
    smt_create_operation op;
@@ -600,7 +600,7 @@ uint32_t smt_database_fixture::create_smt( signed_transaction& tx, const string&
    }
    FC_LOG_AND_RETHROW();
 
-   return op.symbol.to_nai();
+   return op.symbol;
 }
 
 #endif

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -252,7 +252,7 @@ struct smt_database_fixture : public clean_database_fixture
    smt_database_fixture();
    virtual ~smt_database_fixture();
 
-   uint32_t create_smt( signed_transaction& trx, const string& account_name, const fc::ecc::private_key& key,
+   asset_symbol_type create_smt( signed_transaction& trx, const string& account_name, const fc::ecc::private_key& key,
       uint8_t token_decimal_places );
 };
 #endif

--- a/tests/tests/smt_tests.cpp
+++ b/tests/tests/smt_tests.cpp
@@ -281,12 +281,12 @@ BOOST_AUTO_TEST_CASE( setup_emissions_apply )
 
       // Create SMT.
       signed_transaction ty;
-      op.nai = create_smt(ty, "alice", alice_private_key, 3);
-      FC_ASSERT( op.nai == alice_symbol.to_nai(), "SMT symbol mismatch ${s1} vs ${s2}",
-         ("s1", op.nai)("s2", alice_symbol.to_nai()) );
+      op.symbol = create_smt(ty, "alice", alice_private_key, 3);
+      FC_ASSERT( op.symbol == alice_symbol, "SMT symbol mismatch ${s1} vs ${s2}",
+         ("s1", op.symbol.to_nai())("s2", alice_symbol.to_nai()) );
 
       // TODO: Replace the code below with account setup operation execution once its implemented.
-      const steem::chain::smt_token_object* smt = db->find< steem::chain::smt_token_object, by_nai >( alice_symbol.to_nai() );
+      const steem::chain::smt_token_object* smt = db->find< steem::chain::smt_token_object, by_symbol >( alice_symbol );
       FC_ASSERT( smt != nullptr, "The SMT has just been created!" );
       FC_ASSERT( smt->phase < steem::chain::smt_token_object::smt_phase::setup_completed, "Who closed setup phase?!" );
       db->modify( *smt, [&]( steem::chain::smt_token_object& token )
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE( set_setup_parameters_apply )
 
       // create SMT
       signed_transaction ty;
-      op.nai = create_smt(ty, "dany", dany_private_key, 3);
+      op.symbol = create_smt(ty, "dany", dany_private_key, 3);
 
       signed_transaction tz;
       tz.operations.push_back( op );
@@ -523,7 +523,7 @@ BOOST_AUTO_TEST_CASE( runtime_parameters_apply )
       tx.signatures.clear();
 
       //Try to create SMT
-      op.nai = create_smt( tx, "alice", alice_private_key, 3 );
+      op.symbol = create_smt( tx, "alice", alice_private_key, 3 );
       tx.operations.clear();
       tx.signatures.clear();
 


### PR DESCRIPTION
Full asset_symbol_type is now used instead of "public" nai string representation #1676