### PR TITLE
sign_transaction:  Report errors

### DIFF
--- a/programs/util/sign_transaction.cpp
+++ b/programs/util/sign_transaction.cpp
@@ -28,8 +28,14 @@ struct tx_signing_result
    steem::protocol::signature_type  sig;
 };
 
+struct error_result
+{
+   std::string error;
+};
+
 FC_REFLECT( tx_signing_request, (tx)(wif) )
 FC_REFLECT( tx_signing_result, (digest)(sig_digest)(key)(sig) )
+FC_REFLECT( error_result, (error) )
 
 int main(int argc, char** argv, char** envp)
 {
@@ -43,18 +49,28 @@ int main(int argc, char** argv, char** envp)
       if( line == "" )
          continue;
 
-      fc::variant v = fc::json::from_string( line, fc::json::strict_parser );
-      tx_signing_request sreq;
-      fc::from_variant( v, sreq );
-      tx_signing_result sres;
-      sres.tx = sreq.tx;
-      sres.digest = sreq.tx.digest();
-      sres.sig_digest = sreq.tx.sig_digest(STEEM_CHAIN_ID);
+      try
+      {
+         fc::variant v = fc::json::from_string( line, fc::json::strict_parser );
+         tx_signing_request sreq;
+         fc::from_variant( v, sreq );
+         tx_signing_result sres;
+         sres.tx = sreq.tx;
+         sres.digest = sreq.tx.digest();
+         sres.sig_digest = sreq.tx.sig_digest(STEEM_CHAIN_ID);
 
-      fc::ecc::private_key priv_key = *steem::utilities::wif_to_key( sreq.wif );
-      sres.sig = priv_key.sign_compact( sres.sig_digest );
-      sres.key = steem::protocol::public_key_type( priv_key.get_public_key() );
-      std::cout << fc::json::to_string( sres ) << std::endl;
+         fc::ecc::private_key priv_key = *steem::utilities::wif_to_key( sreq.wif );
+         sres.sig = priv_key.sign_compact( sres.sig_digest );
+         sres.key = steem::protocol::public_key_type( priv_key.get_public_key() );
+         std::string sres_str = fc::json::to_string( sres );
+         std::cout << "{\"result\":" << sres_str << "}" << std::endl;
+      }
+      catch( const fc::exception& e )
+      {
+         error_result eresult;
+         eresult.error = e.to_detail_string();
+         std::cout << fc::json::to_string( eresult ) << std::endl;
+      }
    }
    return 0;
 }


### PR DESCRIPTION
A while ago I created a standalone utility for signing transactions, it takes JSON transaction objects and WIF keys on stdin, performs the signing task, and sends the result to stdout.

This patch changes the output format to report errors.  The new version of the utility is not backward compatible with the output that was produced by the old version, but AFAIK there are no users of this utility (except for a testnet experiment I did long ago and abandoned before it was complete).
