### PR TITLE
debug_node_plugin:  Refactor and extend functionality of debug_generate_blocks()

### DIFF
--- a/libraries/plugins/apis/debug_node_api/debug_node_api.cpp
+++ b/libraries/plugins/apis/debug_node_api/debug_node_api.cpp
@@ -103,7 +103,9 @@ DEFINE_API( debug_node_api_impl, debug_push_blocks )
 
 DEFINE_API( debug_node_api_impl, debug_generate_blocks )
 {
-   return { _debug_node.debug_generate_blocks( args.debug_key, args.count, chain::database::skip_nothing, 0 ) };
+   debug_generate_blocks_return ret;
+   _debug_node.debug_generate_blocks( ret, args );
+   return ret;
 }
 
 DEFINE_API( debug_node_api_impl, debug_generate_blocks_until )

--- a/libraries/plugins/apis/debug_node_api/include/steem/plugins/debug_node_api/debug_node_api.hpp
+++ b/libraries/plugins/apis/debug_node_api/include/steem/plugins/debug_node_api/debug_node_api.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <steem/plugins/json_rpc/utility.hpp>
 #include <steem/plugins/database_api/database_api_objects.hpp>
+#include <steem/plugins/debug_node/debug_node_plugin.hpp>
 
 #include <steem/protocol/types.hpp>
 
@@ -25,14 +26,6 @@ struct debug_push_blocks_return
 {
    uint32_t                                  blocks;
 };
-
-struct debug_generate_blocks_args
-{
-   std::string                               debug_key;
-   uint32_t                                  count;
-};
-
-typedef debug_push_blocks_return debug_generate_blocks_return;
 
 struct debug_generate_blocks_until_args
 {
@@ -123,9 +116,6 @@ FC_REFLECT( steem::plugins::debug_node::debug_push_blocks_args,
 
 FC_REFLECT( steem::plugins::debug_node::debug_push_blocks_return,
             (blocks) )
-
-FC_REFLECT( steem::plugins::debug_node::debug_generate_blocks_args,
-            (debug_key)(count) )
 
 FC_REFLECT( steem::plugins::debug_node::debug_generate_blocks_until_args,
             (debug_key)(head_block_time)(generate_sparsely) )

--- a/libraries/plugins/debug_node/include/steem/plugins/debug_node/debug_node_plugin.hpp
+++ b/libraries/plugins/debug_node/include/steem/plugins/debug_node/debug_node_plugin.hpp
@@ -20,6 +20,20 @@ using namespace appbase;
 
 namespace detail { class debug_node_plugin_impl; }
 
+struct debug_generate_blocks_args
+{
+   std::string                               debug_key;
+   uint32_t                                  count = 0;
+   uint32_t                                  skip = steem::chain::database::skip_nothing;
+   uint32_t                                  miss_blocks = 0;
+   bool                                      edit_if_needed = true;
+};
+
+struct debug_generate_blocks_return
+{
+   uint32_t                                  blocks = 0;
+};
+
 class debug_node_plugin : public plugin< debug_node_plugin >
 {
    public:
@@ -58,6 +72,9 @@ class debug_node_plugin : public plugin< debug_node_plugin >
          db.push_block( *head_block, skip );
       }
 
+      void debug_generate_blocks(
+         debug_generate_blocks_return& ret,
+         const debug_generate_blocks_args& args );
 
       uint32_t debug_generate_blocks(
          const std::string& debug_key,
@@ -100,3 +117,14 @@ class debug_node_plugin : public plugin< debug_node_plugin >
 };
 
 } } }
+
+FC_REFLECT( steem::plugins::debug_node::debug_generate_blocks_args,
+            (debug_key)
+            (count)
+            (skip)
+            (miss_blocks)
+            (edit_if_needed)
+          )
+FC_REFLECT( steem::plugins::debug_node::debug_generate_blocks_return,
+            (blocks)
+          )


### PR DESCRIPTION
This PR implements the following functionality for `debug_generate_blocks()`:

- The implementation now accesses the argument / return structures, making it more future-proof by simplifying the implementation of new keyword arguments
- The legacy positional argument implementation still exists because it is used by the unit test framework
- `miss_blocks` is now properly forwarded, it was set to a hardcoded value of `0` by the old code
- New parameter `edit_if_needed` can be set to `false`, in which case it will return when the provided WIF doesn't match the witness key (the previous, still-default behavior is to edit the local DB and produce a chain that isn't accepted by any other node)
