### PR TITLE
Make perform_vesting_share_split() a no-op if it happens at genesis

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -4088,7 +4088,14 @@ void database::perform_vesting_share_split( uint32_t magnitude )
 {
    try
    {
-      modify( get_dynamic_global_properties(), [&]( dynamic_global_property_object& d )
+      const dynamic_global_property_object& dgpo = get_dynamic_global_properties();
+      if( dgpo.head_block_number <= 1 )
+      {
+         ilog( "perform_vesting_share_split() does not execute at genesis" );
+         return;
+      }
+
+      modify( dgpo, [&]( dynamic_global_property_object& d )
       {
          d.total_vesting_shares.amount *= magnitude;
          d.total_reward_shares2 = 0;


### PR DESCRIPTION
When creating a testnet, I've encountered some trouble with total `VESTS` exceeding `STEEM_MAX_SATOSHIS` if the vesting split occurs when only `1.000 TESTS` is vested.  The issue can be fixed by refusing to perform the split hardfork on the genesis block.