### PR TITLE
Fixed typos for Virtual Memory filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ On Linux use the following Virtual Memory configuration for the initial sync and
 
 ```
 echo    75 | sudo tee /proc/sys/vm/dirty_background_ratio
-echo  1000 | sudo tee /proc/sys/vm/dirty_expire_centisec
+echo  1000 | sudo tee /proc/sys/vm/dirty_expire_centisecs
 echo    80 | sudo tee /proc/sys/vm/dirty_ratio
-echo 30000 | sudo tee /proc/sys/vm/dirty_writeback_centisec
+echo 30000 | sudo tee /proc/sys/vm/dirty_writeback_centisecs
 ```


### PR DESCRIPTION
echo  1000 | sudo tee /proc/sys/vm/dirty_expire_centisecs
echo 30000 | sudo tee /proc/sys/vm/dirty_writeback_centisecs

Both should end with an 's', otherwise a File Not Found error occurs.