### PR TITLE
Fixed incorrect commands for Virtual Memory (local PR for #1740)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ On Linux use the following Virtual Memory configuration for the initial sync and
 
 ```
 echo    75 | sudo tee /proc/sys/vm/dirty_background_ratio
-echo  1000 | sudo tee /proc/sys/vm/dirty_expire_centisec
+echo  1000 | sudo tee /proc/sys/vm/dirty_expire_centisecs
 echo    80 | sudo tee /proc/sys/vm/dirty_ratio
-echo 30000 | sudo tee /proc/sys/vm/dirty_writeback_centisec
+echo 30000 | sudo tee /proc/sys/vm/dirty_writeback_centisecs
 ```


### PR DESCRIPTION
Redoing #1740 so it hits CI, also rebased against `develop`.

Sure enough, the wrong commands somehow ended up in there:

```
$ ls /proc/sys/vm | grep centi
dirty_expire_centisecs
dirty_writeback_centisecs
```

I'm guessing it was a careless typo on my part back when this was added.