### PR TITLE
avoid throwing in destructors

### DIFF
--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -102,7 +102,7 @@ clean_database_fixture::~clean_database_fixture()
    if( data_dir )
       db->wipe( data_dir->path(), data_dir->path(), true );
    return;
-} FC_CAPTURE_AND_RETHROW() }
+} FC_CAPTURE_AND_LOG( () ) }
 
 void clean_database_fixture::resize_shared_mem( uint64_t size )
 {
@@ -185,7 +185,7 @@ live_database_fixture::~live_database_fixture()
       db->close();
       return;
    }
-   FC_LOG_AND_RETHROW()
+   FC_CAPTURE_AND_LOG( () )
 }
 
 fc::ecc::private_key database_fixture::generate_private_key(string seed)

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -102,7 +102,9 @@ clean_database_fixture::~clean_database_fixture()
    if( data_dir )
       db->wipe( data_dir->path(), data_dir->path(), true );
    return;
-} FC_CAPTURE_AND_LOG( () ) }
+} FC_CAPTURE_AND_LOG( () )
+   exit(1);
+}
 
 void clean_database_fixture::resize_shared_mem( uint64_t size )
 {
@@ -186,6 +188,7 @@ live_database_fixture::~live_database_fixture()
       return;
    }
    FC_CAPTURE_AND_LOG( () )
+   exit(1);
 }
 
 fc::ecc::private_key database_fixture::generate_private_key(string seed)


### PR DESCRIPTION
this patch avoids throwing an exception in the test destructors, logs the error, and `exit(1)`.