### PR TITLE
get_dev_key.cpp: show help if less than 2 parameters are given

### DIFF
--- a/programs/util/get_dev_key.cpp
+++ b/programs/util/get_dev_key.cpp
@@ -43,7 +43,7 @@ int main( int argc, char** argv )
    {
       std::string dev_key_prefix;
       bool need_help = false;
-      if( argc < 2 )
+      if( argc < 3 )
          need_help = true;
       else
       {
@@ -56,7 +56,6 @@ int main( int argc, char** argv )
 
       if( need_help )
       {
-         std::cerr << argc << " " << argv[1]  << "\n";
          std::cerr << "get-dev-key <prefix> <suffix> ...\n"
              "\n"
              "example:\n"


### PR DESCRIPTION
also remove the (debugging?) first line shown before the help