### PR TITLE
Don't throw exception in test fixture destructors #1755

### DIFF
--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -102,7 +102,7 @@ clean_database_fixture::~clean_database_fixture()
    if( data_dir )
       db->wipe( data_dir->path(), data_dir->path(), true );
    return;
-} FC_CAPTURE_AND_RETHROW() }
+} FC_CAPTURE_AND_LOG( () ) }
 
 void clean_database_fixture::resize_shared_mem( uint64_t size )
 {
@@ -185,7 +185,7 @@ live_database_fixture::~live_database_fixture()
       db->close();
       return;
    }
-   FC_LOG_AND_RETHROW()
+   FC_CAPTURE_AND_LOG( () )
 }
 
 fc::ecc::private_key database_fixture::generate_private_key(string seed)

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -102,7 +102,9 @@ clean_database_fixture::~clean_database_fixture()
    if( data_dir )
       db->wipe( data_dir->path(), data_dir->path(), true );
    return;
-} FC_CAPTURE_AND_LOG( () ) }
+} FC_CAPTURE_AND_LOG( () )
+   exit(1);
+}
 
 void clean_database_fixture::resize_shared_mem( uint64_t size )
 {
@@ -186,6 +188,7 @@ live_database_fixture::~live_database_fixture()
       return;
    }
    FC_CAPTURE_AND_LOG( () )
+   exit(1);
 }
 
 fc::ecc::private_key database_fixture::generate_private_key(string seed)


### PR DESCRIPTION
Local PR for #1755.  Copy-pasting part of my comment from #1753 (with minor editing) to explain the rationale for `exit(1)`:

The problem here is that [a previous version of this] change will lose the information that an exception is thrown. Let's do something more noisy here than merely logging the exception. The "proper" thing to do is to have the destructor set a flag accessible to some outer context and then have the outer context check the flag and throw an exception, but this seems complicated, especially given that the outer context is provided by Boost macros, not code we control.

But this is in the unit tests. The unit tests' primary function is to be run by the CI script to make sure all is well with every commit. So let's simply `exit(1)`. It's not as ideal as the proper solution, but it is easy to implement and would meet the desired requirements (cause the test process to exit unsuccessfully if an exception is thrown in one of these destructors, fix warnings on g++ 6).
