### PR TITLE
Database fixture NAI generation bug #1738

### DIFF
--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -207,6 +207,10 @@ asset_symbol_type database_fixture::name_to_asset_symbol( const std::string& nam
 
    uint32_t h0 = (boost::endian::native_to_big( fc::sha256::hash( name )._hash[0] ) >> 32) & 0x7FFFFFF;
    FC_ASSERT( decimal_places <= STEEM_ASSET_MAX_DECIMALS, "Invalid decimal_places" );
+   while( h0 > SMT_MAX_NAI )
+      h0 -= SMT_MAX_NAI;
+   while( h0 < SMT_MIN_NAI )
+      h0 += SMT_MIN_NAI;
    uint32_t asset_num = (h0 << 5) | 0x10 | decimal_places;
    return asset_symbol_type::from_asset_num( asset_num );
 }

--- a/tests/tests/smt_tests.cpp
+++ b/tests/tests/smt_tests.cpp
@@ -23,6 +23,24 @@ using boost::container::flat_set;
 
 BOOST_FIXTURE_TEST_SUITE( smt_tests, smt_database_fixture )
 
+BOOST_AUTO_TEST_CASE( asset_symbol_validate )
+{
+   try
+   {
+      auto check_validate = [&]( const std::string& name, uint8_t decimal_places )
+      {
+         asset_symbol_type sym = name_to_asset_symbol( name, decimal_places );
+         sym.validate();
+      };
+
+      // specific cases in https://github.com/steemit/steem/issues/1738
+      check_validate( "0", 0 );
+      check_validate( "d2", 1 );
+      check_validate( "da1", 1 );
+   }
+   FC_LOG_AND_RETHROW()
+}
+
 BOOST_AUTO_TEST_CASE( smt_create_validate )
 {
    try


### PR DESCRIPTION
PR for #1738.

The NAI generation helper method in `database_fixture` can generate values that are out of range, causing `validate()` to fail.  Here's a simple fix and a test case to check that some previously failing values now pass.