### PR TITLE
Remaining implementation of issue 1554

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -4275,4 +4275,27 @@ void database::retally_witness_vote_counts( bool force )
    }
 }
 
+#ifdef STEEM_ENABLE_SMT
+vector< asset_symbol_type > database::get_smt_next_identifier()
+{
+   // This is temporary dummy implementation using simple counter as nai source (_next_available_nai).
+   // Although a container of available nais is returned, it contains only one entry for simplicity.
+   // Note that no decimal places argument is required from SMT creator at this stage.
+   // This is because asset_symbol_type's to_string method omits the precision when serializing.
+   // For appropriate use of this method see e.g. smt_database_fixture::create_smt
+   
+   uint8_t decimal_places = 0;
+   FC_ASSERT( _next_available_nai >= SMT_MIN_NAI );
+   FC_ASSERT( _next_available_nai <= SMT_MAX_NAI, "Out of available NAI numbers." );
+
+   uint32_t asset_num = (_next_available_nai++ << 5) | 0x10 | decimal_places;
+
+   asset_symbol_type new_symbol = asset_symbol_type::from_asset_num( asset_num );
+   new_symbol.validate();
+   FC_ASSERT( new_symbol.space() == asset_symbol_type::smt_nai_space );
+
+   return std::move( vector< asset_symbol_type >( 1, new_symbol ) );
+}
+#endif
+
 } } //steem::chain

--- a/libraries/chain/include/steem/chain/database.hpp
+++ b/libraries/chain/include/steem/chain/database.hpp
@@ -422,6 +422,18 @@ namespace steem { namespace chain {
          bool disable_low_mem_warning = true;
 #endif
 
+#ifdef STEEM_ENABLE_SMT
+         ///Smart Media Tokens related methods
+         ///@{
+
+         /**
+          * @return a list of available NAIs.
+         */
+         vector< asset_symbol_type > get_smt_next_identifier();
+
+         ///@}
+#endif         
+
    protected:
          //Mark pop_undo() as protected -- we do not want outside calling pop_undo(); it should call pop_block() instead
          //void pop_undo() { object_database::pop_undo(); }
@@ -488,6 +500,7 @@ namespace steem { namespace chain {
          uint32_t                      _next_flush_block = 0;
 
          uint32_t                      _last_free_gb_printed = 0;
+         uint32_t                      _next_available_nai = 1;
 
          flat_map< std::string, std::shared_ptr< custom_operation_interpreter > >   _custom_operation_interpreters;
          std::string                       _json_schema;

--- a/libraries/plugins/apis/database_api/database_api.cpp
+++ b/libraries/plugins/apis/database_api/database_api.cpp
@@ -60,6 +60,9 @@ class database_api_impl
          (get_potential_signatures)
          (verify_authority)
          (verify_account_authority)
+#ifdef STEEM_ENABLE_SMT
+         (get_smt_next_identifier)
+#endif
       )
 
       template< typename ResultType >
@@ -1816,5 +1819,28 @@ DEFINE_API( database_api_impl, verify_account_authority )
 
    return verify_authority( vap );
 }
+
+#ifdef STEEM_ENABLE_SMT
+//////////////////////////////////////////////////////////////////////
+//                                                                  //
+// SMT                                                              //
+//                                                                  //
+//////////////////////////////////////////////////////////////////////
+
+DEFINE_API( database_api, get_smt_next_identifier )
+{
+   return my->_db.with_read_lock( [&]()
+   {
+      return my->get_smt_next_identifier( args );
+   });
+}
+
+DEFINE_API( database_api_impl, get_smt_next_identifier )
+{
+   get_smt_next_identifier_return result;
+   result.nais = _db.get_smt_next_identifier();
+   return result;
+}
+#endif
 
 } } } // steem::plugins::database_api

--- a/libraries/plugins/apis/database_api/include/steem/plugins/database_api/database_api.hpp
+++ b/libraries/plugins/apis/database_api/include/steem/plugins/database_api/database_api.hpp
@@ -125,6 +125,12 @@ class database_api
          * @return true if the signers have enough authority to authorize an account
          */
          (verify_account_authority)
+#ifdef STEEM_ENABLE_SMT
+         /**
+         * @return array of Numeric Asset Identifier (NAI) available to be used for new SMT to be created.
+         */
+         (get_smt_next_identifier)
+#endif
       )
 
    private:

--- a/libraries/plugins/apis/database_api/include/steem/plugins/database_api/database_api_args.hpp
+++ b/libraries/plugins/apis/database_api/include/steem/plugins/database_api/database_api_args.hpp
@@ -523,6 +523,15 @@ struct verify_account_authority_args
 
 typedef verify_authority_return verify_account_authority_return;
 
+#ifdef STEEM_ENABLE_SMT
+typedef void_type get_smt_next_identifier_args;
+
+struct get_smt_next_identifier_return
+{
+   vector< asset_symbol_type > nais;
+};
+#endif
+
 } } } // steem::database_api
 
 FC_REFLECT_ENUM( steem::plugins::database_api::sort_order_type,
@@ -733,3 +742,8 @@ FC_REFLECT( steem::plugins::database_api::verify_authority_return,
 FC_REFLECT( steem::plugins::database_api::verify_account_authority_args,
    (account)
    (signers) )
+
+#ifdef STEEM_ENABLE_SMT
+FC_REFLECT( steem::plugins::database_api::get_smt_next_identifier_return,
+   (nais) )
+#endif

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -594,7 +594,12 @@ asset_symbol_type smt_database_fixture::create_smt( signed_transaction& tx, cons
       fund( account_name, 10 * 1000 * 1000 );
       convert( account_name, ASSET( "5000.000 TESTS" ) );
 
-      op.symbol = database_fixture::name_to_asset_symbol(account_name, token_decimal_places);
+      // The list of available nais is not dependent on SMT desired precision (token_decimal_places).
+      auto available_nais =  db->get_smt_next_identifier();
+      FC_ASSERT( available_nais.size() > 0, "No available nai returned by get_smt_next_identifier." );
+      const asset_symbol_type& new_nai = available_nais[0];
+      // Note that token's precision is needed now, when creating actual symbol.
+      op.symbol = asset_symbol_type::from_nai( new_nai.to_nai(), token_decimal_places );
       op.precision = op.symbol.decimals();
       op.smt_creation_fee = ASSET( "1000.000 TBD" );
       op.control_account = account_name;

--- a/tests/tests/smt_tests.cpp
+++ b/tests/tests/smt_tests.cpp
@@ -279,14 +279,12 @@ BOOST_AUTO_TEST_CASE( setup_emissions_apply )
    try
    {
       ACTORS( (alice)(bob) )
-      SMT_SYMBOL( alice, 3 );
 
       smt_setup_emissions_operation op;
       op.control_account = "alice";
       fc::time_point now = fc::time_point::now();
       op.schedule_time = now;
       op.emissions_unit.token_unit["bob"] = 10;
-      op.lep_abs_amount = op.rep_abs_amount = asset( 1000, alice_symbol );
 
       signed_transaction tx;
 
@@ -300,11 +298,10 @@ BOOST_AUTO_TEST_CASE( setup_emissions_apply )
       // Create SMT.
       signed_transaction ty;
       op.symbol = create_smt(ty, "alice", alice_private_key, 3);
-      FC_ASSERT( op.symbol == alice_symbol, "SMT symbol mismatch ${s1} vs ${s2}",
-         ("s1", op.symbol.to_nai())("s2", alice_symbol.to_nai()) );
-
+      op.lep_abs_amount = op.rep_abs_amount = asset( 1000, op.symbol );
+      
       // TODO: Replace the code below with account setup operation execution once its implemented.
-      const steem::chain::smt_token_object* smt = db->find< steem::chain::smt_token_object, by_symbol >( alice_symbol );
+      const steem::chain::smt_token_object* smt = db->find< steem::chain::smt_token_object, by_symbol >( op.symbol );
       FC_ASSERT( smt != nullptr, "The SMT has just been created!" );
       FC_ASSERT( smt->phase < steem::chain::smt_token_object::smt_phase::setup_completed, "Who closed setup phase?!" );
       db->modify( *smt, [&]( steem::chain::smt_token_object& token )


### PR DESCRIPTION
Added dummy get_smt_next_identifier implementation that allows for early use of smt creation in dedicated testnet and completes issue #1554