### PR TITLE
Fix wrong amount of withdrawn VESTS

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -1471,7 +1471,7 @@ void database::process_vesting_withdrawals()
       if( to_withdraw > 0 )
          adjust_proxied_witness_votes( from_account, -to_withdraw );
 
-      push_virtual_operation( fill_vesting_withdraw_operation( from_account.name, from_account.name, asset( to_withdraw, VESTS_SYMBOL ), converted_steem ) );
+      push_virtual_operation( fill_vesting_withdraw_operation( from_account.name, from_account.name, asset( to_convert, VESTS_SYMBOL ), converted_steem ) );
    }
 }
 


### PR DESCRIPTION
When vesting withdrawals are processed and withdraw routes have been set for that account, several virtual operations are created - one for each withdraw route, and one for the rest. In that final vop for the rest, the amount of VESTS is wrong: it contains the full withdrawal rate and does not take into account that part of the rate has already been paid out through the withdraw routes.

Fortunately, the actual withdrawal uses the correct amount. The bug affects only the virtual operation.

This PR contains a simple fix.