### PR TITLE
Templated Authority Verification

### DIFF
--- a/libraries/protocol/include/steem/protocol/operation_util.hpp
+++ b/libraries/protocol/include/steem/protocol/operation_util.hpp
@@ -10,6 +10,42 @@
 #include <string>
 #include <vector>
 
+namespace steem { namespace protocol {
+
+struct get_required_auth_visitor
+{
+   typedef void result_type;
+
+   flat_set< account_name_type >&        active;
+   flat_set< account_name_type >&        owner;
+   flat_set< account_name_type >&        posting;
+   std::vector< authority >&  other;
+
+   get_required_auth_visitor(
+         flat_set< account_name_type >& a,
+         flat_set< account_name_type >& own,
+         flat_set< account_name_type >& post,
+         std::vector< authority >& oth )
+      : active( a ), owner( own ), posting( post ), other( oth ) {}
+
+   template< typename ...Ts >
+   void operator()( const fc::static_variant< Ts... >& v )
+   {
+      v.visit( *this );
+   }
+
+   template< typename T >
+   void operator()( const T& v )const
+   {
+      v.get_required_active_authorities( active );
+      v.get_required_owner_authorities( owner );
+      v.get_required_posting_authorities( posting );
+      v.get_required_authorities( other );
+   }
+};
+
+} } // steem::protocol
+
 //
 // Place STEEM_DECLARE_OPERATION_TYPE in a .hpp file to declare
 // functions related to your operation type

--- a/libraries/protocol/include/steem/protocol/operation_util_impl.hpp
+++ b/libraries/protocol/include/steem/protocol/operation_util_impl.hpp
@@ -46,32 +46,6 @@ struct operation_validate_visitor
    void operator()( const T& v )const { v.validate(); }
 };
 
-struct operation_get_required_auth_visitor
-{
-   typedef void result_type;
-
-   flat_set< account_name_type >&        active;
-   flat_set< account_name_type >&        owner;
-   flat_set< account_name_type >&        posting;
-   std::vector< authority >&  other;
-
-   operation_get_required_auth_visitor(
-         flat_set< account_name_type >& a,
-         flat_set< account_name_type >& own,
-         flat_set< account_name_type >& post,
-         std::vector< authority >& oth )
-      : active( a ), owner( own ), posting( post ), other( oth ) {}
-
-   template< typename T >
-   void operator()( const T& v )const
-   {
-      v.get_required_active_authorities( active );
-      v.get_required_owner_authorities( owner );
-      v.get_required_posting_authorities( posting );
-      v.get_required_authorities( other );
-   }
-};
-
 } } // steem::protocol
 
 //
@@ -129,7 +103,7 @@ void operation_get_required_authorities( const OperationType& op,          \
                                          flat_set< account_name_type >& posting,        \
                                          std::vector< authority >& other )     \
 {                                                                          \
-   op.visit( steem::protocol::operation_get_required_auth_visitor( active, owner, posting, other ) ); \
+   op.visit( steem::protocol::get_required_auth_visitor( active, owner, posting, other ) ); \
 }                                                                          \
                                                                            \
 } } /* steem::protocol */

--- a/libraries/protocol/include/steem/protocol/transaction.hpp
+++ b/libraries/protocol/include/steem/protocol/transaction.hpp
@@ -91,17 +91,6 @@ namespace steem { namespace protocol {
       void clear() { operations.clear(); signatures.clear(); }
    };
 
-   void verify_authority( const vector<operation>& ops, const flat_set<public_key_type>& sigs,
-                          const authority_getter& get_active,
-                          const authority_getter& get_owner,
-                          const authority_getter& get_posting,
-                          uint32_t max_recursion = STEEM_MAX_SIG_CHECK_DEPTH,
-                          bool allow_committe = false,
-                          const flat_set< account_name_type >& active_aprovals = flat_set< account_name_type >(),
-                          const flat_set< account_name_type >& owner_aprovals = flat_set< account_name_type >(),
-                          const flat_set< account_name_type >& posting_approvals = flat_set< account_name_type >());
-
-
    struct annotated_signed_transaction : public signed_transaction {
       annotated_signed_transaction(){}
       annotated_signed_transaction( const signed_transaction& trx )

--- a/libraries/protocol/include/steem/protocol/transaction_util.hpp
+++ b/libraries/protocol/include/steem/protocol/transaction_util.hpp
@@ -1,0 +1,96 @@
+#pragma once
+#include <steem/protocol/sign_state.hpp>
+#include <steem/protocol/exceptions.hpp>
+
+namespace steem { namespace protocol {
+
+void verify_authority( const vector<operation>& ops, const flat_set<public_key_type>& sigs,
+                       const authority_getter& get_active,
+                       const authority_getter& get_owner,
+                       const authority_getter& get_posting,
+                       uint32_t max_recursion_depth = STEEM_MAX_SIG_CHECK_DEPTH,
+                       bool allow_committe = false,
+                       const flat_set< account_name_type >& active_approvals = flat_set< account_name_type >(),
+                       const flat_set< account_name_type >& owner_approvals = flat_set< account_name_type >(),
+                       const flat_set< account_name_type >& posting_approvals = flat_set< account_name_type >()
+                       )
+{ try {
+   flat_set< account_name_type > required_active;
+   flat_set< account_name_type > required_owner;
+   flat_set< account_name_type > required_posting;
+   vector< authority > other;
+
+   for( const auto& op : ops )
+      operation_get_required_authorities( op, required_active, required_owner, required_posting, other );
+
+   /**
+    *  Transactions with operations required posting authority cannot be combined
+    *  with transactions requiring active or owner authority. This is for ease of
+    *  implementation. Future versions of authority verification may be able to
+    *  check for the merged authority of active and posting.
+    */
+   if( required_posting.size() ) {
+      FC_ASSERT( required_active.size() == 0 );
+      FC_ASSERT( required_owner.size() == 0 );
+      FC_ASSERT( other.size() == 0 );
+
+      flat_set< public_key_type > avail;
+      sign_state s(sigs,get_posting,avail);
+      s.max_recursion = max_recursion_depth;
+      for( auto& id : posting_approvals )
+         s.approved_by.insert( id );
+      for( const auto& id : required_posting )
+      {
+         STEEM_ASSERT( s.check_authority(id) ||
+                          s.check_authority(get_active(id)) ||
+                          s.check_authority(get_owner(id)),
+                          tx_missing_posting_auth, "Missing Posting Authority ${id}",
+                          ("id",id)
+                          ("posting",get_posting(id))
+                          ("active",get_active(id))
+                          ("owner",get_owner(id)) );
+      }
+      STEEM_ASSERT(
+         !s.remove_unused_signatures(),
+         tx_irrelevant_sig,
+         "Unnecessary signature(s) detected"
+         );
+      return;
+   }
+
+   flat_set< public_key_type > avail;
+   sign_state s(sigs,get_active,avail);
+   s.max_recursion = max_recursion_depth;
+   for( auto& id : active_approvals )
+      s.approved_by.insert( id );
+   for( auto& id : owner_approvals )
+      s.approved_by.insert( id );
+
+   for( const auto& auth : other )
+   {
+      STEEM_ASSERT( s.check_authority(auth), tx_missing_other_auth, "Missing Authority", ("auth",auth)("sigs",sigs) );
+   }
+
+   // fetch all of the top level authorities
+   for( const auto& id : required_active )
+   {
+      STEEM_ASSERT( s.check_authority(id) ||
+                       s.check_authority(get_owner(id)),
+                       tx_missing_active_auth, "Missing Active Authority ${id}", ("id",id)("auth",get_active(id))("owner",get_owner(id)) );
+   }
+
+   for( const auto& id : required_owner )
+   {
+      STEEM_ASSERT( owner_approvals.find(id) != owner_approvals.end() ||
+                       s.check_authority(get_owner(id)),
+                       tx_missing_owner_auth, "Missing Owner Authority ${id}", ("id",id)("auth",get_owner(id)) );
+   }
+
+   STEEM_ASSERT(
+      !s.remove_unused_signatures(),
+      tx_irrelevant_sig,
+      "Unnecessary signature(s) detected"
+      );
+} FC_CAPTURE_AND_RETHROW( (ops)(sigs) ) }
+
+} } // steem::protocol

--- a/libraries/protocol/include/steem/protocol/transaction_util.hpp
+++ b/libraries/protocol/include/steem/protocol/transaction_util.hpp
@@ -4,7 +4,8 @@
 
 namespace steem { namespace protocol {
 
-void verify_authority( const vector<operation>& ops, const flat_set<public_key_type>& sigs,
+template< typename AuthContainerType >
+void verify_authority( const vector<AuthContainerType>& auth_containers, const flat_set<public_key_type>& sigs,
                        const authority_getter& get_active,
                        const authority_getter& get_owner,
                        const authority_getter& get_posting,
@@ -20,8 +21,10 @@ void verify_authority( const vector<operation>& ops, const flat_set<public_key_t
    flat_set< account_name_type > required_posting;
    vector< authority > other;
 
-   for( const auto& op : ops )
-      operation_get_required_authorities( op, required_active, required_owner, required_posting, other );
+   get_required_auth_visitor auth_visitor( required_active, required_owner, required_posting, other );
+
+   for( const auto& a : auth_containers )
+      auth_visitor( a );
 
    /**
     *  Transactions with operations required posting authority cannot be combined
@@ -91,6 +94,6 @@ void verify_authority( const vector<operation>& ops, const flat_set<public_key_t
       tx_irrelevant_sig,
       "Unnecessary signature(s) detected"
       );
-} FC_CAPTURE_AND_RETHROW( (ops)(sigs) ) }
+} FC_CAPTURE_AND_RETHROW( (auth_containers)(sigs) ) }
 
 } } // steem::protocol

--- a/libraries/protocol/transaction.cpp
+++ b/libraries/protocol/transaction.cpp
@@ -1,6 +1,6 @@
 
 #include <steem/protocol/transaction.hpp>
-#include <steem/protocol/exceptions.hpp>
+#include <steem/protocol/transaction_util.hpp>
 
 #include <fc/io/raw.hpp>
 #include <fc/bitutil.hpp>
@@ -81,96 +81,6 @@ void transaction::get_required_authorities( flat_set< account_name_type >& activ
    for( const auto& op : operations )
       operation_get_required_authorities( op, active, owner, posting, other );
 }
-
-void verify_authority( const vector<operation>& ops, const flat_set<public_key_type>& sigs,
-                       const authority_getter& get_active,
-                       const authority_getter& get_owner,
-                       const authority_getter& get_posting,
-                       uint32_t max_recursion_depth,
-                       bool  allow_committe,
-                       const flat_set< account_name_type >& active_aprovals,
-                       const flat_set< account_name_type >& owner_approvals,
-                       const flat_set< account_name_type >& posting_approvals
-                       )
-{ try {
-   flat_set< account_name_type > required_active;
-   flat_set< account_name_type > required_owner;
-   flat_set< account_name_type > required_posting;
-   vector< authority > other;
-
-   for( const auto& op : ops )
-      operation_get_required_authorities( op, required_active, required_owner, required_posting, other );
-
-   /**
-    *  Transactions with operations required posting authority cannot be combined
-    *  with transactions requiring active or owner authority. This is for ease of
-    *  implementation. Future versions of authority verification may be able to
-    *  check for the merged authority of active and posting.
-    */
-   if( required_posting.size() ) {
-      FC_ASSERT( required_active.size() == 0 );
-      FC_ASSERT( required_owner.size() == 0 );
-      FC_ASSERT( other.size() == 0 );
-
-      flat_set< public_key_type > avail;
-      sign_state s(sigs,get_posting,avail);
-      s.max_recursion = max_recursion_depth;
-      for( auto& id : posting_approvals )
-         s.approved_by.insert( id );
-      for( const auto& id : required_posting )
-      {
-         STEEM_ASSERT( s.check_authority(id) ||
-                          s.check_authority(get_active(id)) ||
-                          s.check_authority(get_owner(id)),
-                          tx_missing_posting_auth, "Missing Posting Authority ${id}",
-                          ("id",id)
-                          ("posting",get_posting(id))
-                          ("active",get_active(id))
-                          ("owner",get_owner(id)) );
-      }
-      STEEM_ASSERT(
-         !s.remove_unused_signatures(),
-         tx_irrelevant_sig,
-         "Unnecessary signature(s) detected"
-         );
-      return;
-   }
-
-   flat_set< public_key_type > avail;
-   sign_state s(sigs,get_active,avail);
-   s.max_recursion = max_recursion_depth;
-   for( auto& id : active_aprovals )
-      s.approved_by.insert( id );
-   for( auto& id : owner_approvals )
-      s.approved_by.insert( id );
-
-   for( const auto& auth : other )
-   {
-      STEEM_ASSERT( s.check_authority(auth), tx_missing_other_auth, "Missing Authority", ("auth",auth)("sigs",sigs) );
-   }
-
-   // fetch all of the top level authorities
-   for( const auto& id : required_active )
-   {
-      STEEM_ASSERT( s.check_authority(id) ||
-                       s.check_authority(get_owner(id)),
-                       tx_missing_active_auth, "Missing Active Authority ${id}", ("id",id)("auth",get_active(id))("owner",get_owner(id)) );
-   }
-
-   for( const auto& id : required_owner )
-   {
-      STEEM_ASSERT( owner_approvals.find(id) != owner_approvals.end() ||
-                       s.check_authority(get_owner(id)),
-                       tx_missing_owner_auth, "Missing Owner Authority ${id}", ("id",id)("auth",get_owner(id)) );
-   }
-
-   STEEM_ASSERT(
-      !s.remove_unused_signatures(),
-      tx_irrelevant_sig,
-      "Unnecessary signature(s) detected"
-      );
-} FC_CAPTURE_AND_RETHROW( (ops)(sigs) ) }
-
 
 flat_set<public_key_type> signed_transaction::get_signature_keys( const chain_id_type& chain_id )const
 { try {


### PR DESCRIPTION
Related to #1674 
Each commit was originally pushed individually as to prove successful CI on each change.

These are the consensus code changes required for #1674. The code in this branch should be equivalent to code in `develop` and should not change consensus behavior in any way. Reviewing this code should be focused on this and design of the refactor.