### PR TITLE
Implement testing scenarios related to smt create operation

### DIFF
--- a/libraries/chain/include/steem/chain/smt_objects/smt_token_object.hpp
+++ b/libraries/chain/include/steem/chain/smt_objects/smt_token_object.hpp
@@ -25,6 +25,11 @@ public:
       c( *this );
    }
 
+   uint32_t get_nai() const
+   {
+      return symbol.to_nai();
+   }
+
    // id_type is actually oid<smt_token_object>
    id_type           id;
 
@@ -65,6 +70,7 @@ public:
 };
 
 struct by_symbol;
+struct by_nai;
 struct by_control_account;
 
 typedef multi_index_container <
@@ -74,6 +80,8 @@ typedef multi_index_container <
          member< smt_token_object, smt_token_id_type, &smt_token_object::id > >,
       ordered_unique< tag< by_symbol >,
          member< smt_token_object, asset_symbol_type, &smt_token_object::symbol > >,
+      ordered_unique< tag< by_nai >,
+         const_mem_fun< smt_token_object, uint32_t, &smt_token_object::get_nai > >,
       ordered_non_unique< tag< by_control_account >,
          member< smt_token_object, account_name_type, &smt_token_object::control_account > >
    >,

--- a/libraries/chain/smt_evaluator.cpp
+++ b/libraries/chain/smt_evaluator.cpp
@@ -70,6 +70,10 @@ void smt_create_evaluator::do_apply( const smt_create_operation& o )
    FC_ASSERT( _db.has_hardfork( STEEM_SMT_HARDFORK ), "SMT functionality not enabled until hardfork ${hf}", ("hf", STEEM_SMT_HARDFORK) );
    const dynamic_global_property_object& dgpo = _db.get_dynamic_global_properties();
 
+   // Check that SMT with given symbol has not been created already.
+   FC_ASSERT( (_db.find< smt_token_object, by_nai >( o.symbol.to_nai() ) == nullptr),
+      "SMT ${nai} has already been created.", ("nai", o.symbol.to_nai()));
+
    asset effective_elevation_fee;
 
    FC_ASSERT( dgpo.smt_creation_fee.symbol == STEEM_SYMBOL || dgpo.smt_creation_fee.symbol == SBD_SYMBOL,

--- a/libraries/chain/smt_evaluator.cpp
+++ b/libraries/chain/smt_evaluator.cpp
@@ -70,7 +70,9 @@ void smt_create_evaluator::do_apply( const smt_create_operation& o )
    FC_ASSERT( _db.has_hardfork( STEEM_SMT_HARDFORK ), "SMT functionality not enabled until hardfork ${hf}", ("hf", STEEM_SMT_HARDFORK) );
    const dynamic_global_property_object& dgpo = _db.get_dynamic_global_properties();
 
-   // Check that SMT with given symbol has not been created already.
+   // Check that SMT with given nai has not been created already.
+   // Note that symbols with the same nai and different precision (decimal places) are not allowed,
+   // therefore we can't use 'by_symbol' index here, as we need to strip the symbol from precision info.
    FC_ASSERT( (_db.find< smt_token_object, by_nai >( o.symbol.to_nai() ) == nullptr),
       "SMT ${nai} has already been created.", ("nai", o.symbol.to_nai()));
 

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -697,6 +697,21 @@ void smt_database_fixture::create_smt_3( const char* control_account_name, const
    FC_LOG_AND_RETHROW();
 }
 
+void smt_database_fixture::create_invalid_smt( const char* control_account_name, const fc::ecc::private_key& key )
+{
+   // Fail due to precision too big.
+   smt_create_operation op_precision;
+   STEEM_REQUIRE_THROW( set_create_op(&op_precision, control_account_name, "smt", STEEM_ASSET_MAX_DECIMALS + 1), fc::assert_exception );
+   // Fail due to invalid token name.
+   smt_create_operation op_name;
+   set_create_op(&op_name, control_account_name, "alice1", 0);
+   signed_transaction tx;
+   tx.operations.push_back( op_name );
+   tx.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
+   tx.sign( key, db->get_chain_id() );
+   STEEM_REQUIRE_THROW( db->push_transaction( tx, 0 ), fc::assert_exception );
+}
+
 #endif
 
 json_rpc_database_fixture::json_rpc_database_fixture()

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -722,10 +722,6 @@ void smt_database_fixture::create_invalid_smt( const char* control_account_name,
    // Fail due to precision too big.
    smt_create_operation op_precision;
    STEEM_REQUIRE_THROW( set_create_op(&op_precision, control_account_name, "smt", STEEM_ASSET_MAX_DECIMALS + 1), fc::assert_exception );
-   // Fail due to invalid token name.
-   smt_create_operation op_name;
-   set_create_op(&op_name, control_account_name, "alice1", 0);
-   push_invalid_operation(op_name, key, db);
 }
 
 void smt_database_fixture::create_conflicting_smt( const asset_symbol_type existing_smt, const char* control_account_name,

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -256,6 +256,10 @@ struct smt_database_fixture : public clean_database_fixture
       uint8_t token_decimal_places );
 
    void transfer_smt( const string& from, const string& to, const asset& steem );
+
+   typedef std::function< void(const asset_symbol_type& smt1, const asset_symbol_type& smt2, const asset_symbol_type& smt3) > TFollowUpOps;
+   /// Creates 3 different SMTs for provided control account, one with 0 precision, the other two with the same non-zero precision.
+   void create_smt_3( const char* control_account_name, const fc::ecc::private_key& key, TFollowUpOps followUpOps );
 };
 #endif
 

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -260,6 +260,8 @@ struct smt_database_fixture : public clean_database_fixture
    typedef std::function< void(const asset_symbol_type& smt1, const asset_symbol_type& smt2, const asset_symbol_type& smt3) > TFollowUpOps;
    /// Creates 3 different SMTs for provided control account, one with 0 precision, the other two with the same non-zero precision.
    void create_smt_3( const char* control_account_name, const fc::ecc::private_key& key, TFollowUpOps followUpOps );
+   /// Tries to create SMTs with too big precision or invalid name.
+   void create_invalid_smt( const char* control_account_name, const fc::ecc::private_key& key );
 };
 #endif
 

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -262,6 +262,8 @@ struct smt_database_fixture : public clean_database_fixture
    void create_smt_3( const char* control_account_name, const fc::ecc::private_key& key, TFollowUpOps followUpOps );
    /// Tries to create SMTs with too big precision or invalid name.
    void create_invalid_smt( const char* control_account_name, const fc::ecc::private_key& key );
+   /// Tries to create SMTs matching existing one. First attempt with matching precision, second one with different (but valid) precision.
+   void create_conflicting_smt( const asset_symbol_type existing_smt, const char* control_account_name, const fc::ecc::private_key& key );
 };
 #endif
 

--- a/tests/tests/smt_tests.cpp
+++ b/tests/tests/smt_tests.cpp
@@ -539,27 +539,16 @@ BOOST_AUTO_TEST_CASE( runtime_parameters_apply )
       op.runtime_parameters.insert( regeneration );
       op.runtime_parameters.insert( rewards );
 
-      signed_transaction tx;
-
-      tx.operations.push_back( op );
-      tx.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
-      tx.sign( alice_private_key, db->get_chain_id() );
-
       //First we should create SMT
-      STEEM_REQUIRE_THROW( db->push_transaction( tx, 0 ), fc::exception );
-      tx.operations.clear();
-      tx.signatures.clear();
+      FAIL_WITH_OP(op, alice_private_key, fc::assert_exception)
 
-      //Try to create SMT
-      op.symbol = create_smt( tx, "alice", alice_private_key, 3 );
-      tx.operations.clear();
-      tx.signatures.clear();
-
-      //Make transaction again.
-      tx.operations.push_back( op );
-      tx.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
-      tx.sign( alice_private_key, db->get_chain_id() );
-      db->push_transaction( tx, 0 );
+      // Create SMT(s) and continue.
+      create_smt_3("alice", alice_private_key, [&op, this, alice_private_key]
+                                               (const asset_symbol_type& smt1, const asset_symbol_type& smt2, const asset_symbol_type& smt3) {
+         //Make transaction again.
+         op.symbol = smt3;
+         PUSH_OP(op, alice_private_key);
+      });
    }
    FC_LOG_AND_RETHROW()
 }

--- a/tests/tests/smt_tests.cpp
+++ b/tests/tests/smt_tests.cpp
@@ -137,6 +137,9 @@ BOOST_AUTO_TEST_CASE( smt_create_apply )
       // Check the SMT cannot be created twice
       STEEM_REQUIRE_THROW( db->push_transaction( tx, database::skip_transaction_dupe_check ), fc::exception );
 
+      // Check that invalid SMT can't be created
+      create_invalid_smt("alice", alice_private_key);
+
       // TODO:
       // - Check that 1000 TESTS throws
       // - Check that less than 1000 TBD throws

--- a/tests/tests/smt_tests.cpp
+++ b/tests/tests/smt_tests.cpp
@@ -137,6 +137,9 @@ BOOST_AUTO_TEST_CASE( smt_create_apply )
       // Check the SMT cannot be created twice even with different precision.
       create_conflicting_smt(op.symbol, "alice", alice_private_key);
 
+      // Check that another user/account can't be used to create duplicating SMT even with different precision.
+      create_conflicting_smt(op.symbol, "bob", bob_private_key);
+
       // Check that invalid SMT can't be created
       create_invalid_smt("alice", alice_private_key);
 

--- a/tests/tests/smt_tests.cpp
+++ b/tests/tests/smt_tests.cpp
@@ -134,8 +134,8 @@ BOOST_AUTO_TEST_CASE( smt_create_apply )
       convert( "alice", ASSET( "5000.000 TESTS" ) );
       db->push_transaction( tx, 0 );
 
-      // Check the SMT cannot be created twice
-      STEEM_REQUIRE_THROW( db->push_transaction( tx, database::skip_transaction_dupe_check ), fc::exception );
+      // Check the SMT cannot be created twice even with different precision.
+      create_conflicting_smt(op.symbol, "alice", alice_private_key);
 
       // Check that invalid SMT can't be created
       create_invalid_smt("alice", alice_private_key);
@@ -306,6 +306,9 @@ BOOST_AUTO_TEST_CASE( setup_emissions_apply )
       fail_op.schedule_time = now;
       fail_op.emissions_unit.token_unit["bob"] = 10;
       fail_op.lep_abs_amount = fail_op.rep_abs_amount = asset( 1000, alice_symbol );
+
+      // Do invalid attempt at SMT creation.
+      create_invalid_smt("alice", alice_private_key);      
 
       // Fail due to non-existing SMT (too early).
       FAIL_WITH_OP(fail_op,alice_private_key)

--- a/tests/tests/smt_tests.cpp
+++ b/tests/tests/smt_tests.cpp
@@ -290,11 +290,19 @@ BOOST_AUTO_TEST_CASE( set_setup_parameters_authorities )
       db->push_transaction( tx, 0 ); \
    }
 
-#define FAIL_WITH_OP(OP,KEY) \
+#define PUSH_OP_TWICE(OP,KEY) \
    { \
       signed_transaction tx; \
       OP2TX(OP,tx,KEY) \
-      STEEM_REQUIRE_THROW( db->push_transaction( tx, 0 ), fc::assert_exception ); \
+      db->push_transaction( tx, 0 ); \
+      db->push_transaction( tx, database::skip_transaction_dupe_check ); \
+   }
+
+#define FAIL_WITH_OP(OP,KEY,EXCEPTION) \
+   { \
+      signed_transaction tx; \
+      OP2TX(OP,tx,KEY) \
+      STEEM_REQUIRE_THROW( db->push_transaction( tx, 0 ), EXCEPTION ); \
    }
 
 BOOST_AUTO_TEST_CASE( setup_emissions_apply )
@@ -308,13 +316,12 @@ BOOST_AUTO_TEST_CASE( setup_emissions_apply )
       fc::time_point now = fc::time_point::now();
       fail_op.schedule_time = now;
       fail_op.emissions_unit.token_unit["bob"] = 10;
-      fail_op.lep_abs_amount = fail_op.rep_abs_amount = asset( 1000, alice_symbol );
 
       // Do invalid attempt at SMT creation.
       create_invalid_smt("alice", alice_private_key);      
 
       // Fail due to non-existing SMT (too early).
-      FAIL_WITH_OP(fail_op,alice_private_key)
+      FAIL_WITH_OP(fail_op, alice_private_key, fc::assert_exception)
 
       // Create SMT(s) and continue.
       create_smt_3("alice", alice_private_key, [&fail_op, this, alice_private_key]
@@ -337,7 +344,7 @@ BOOST_AUTO_TEST_CASE( setup_emissions_apply )
             token.phase = steem::chain::smt_token_object::smt_phase::setup_completed;
          });
          // Fail due to closed setup phase (too late).
-         FAIL_WITH_OP(fail_op,alice_private_key)
+         FAIL_WITH_OP(fail_op, alice_private_key, fc::assert_exception)
       });
    }
    FC_LOG_AND_RETHROW()
@@ -353,63 +360,44 @@ BOOST_AUTO_TEST_CASE( set_setup_parameters_apply )
       fund( "dany", 5000000 );
       convert( "dany", ASSET( "5000.000 TESTS" ) );
 
-      signed_transaction tx;
+      smt_set_setup_parameters_operation fail_op;
+      fail_op.control_account = "dany";
 
-      smt_set_setup_parameters_operation op;
-      op.control_account = "dany";
+      // Do invalid attempt at SMT creation.
+      create_invalid_smt("dany", dany_private_key);
+      
+      // Fail due to non-existing SMT (too early).
+      FAIL_WITH_OP(fail_op, dany_private_key, fc::assert_exception)
+      
+      // Create SMT(s) and continue.
+      create_smt_3("dany", dany_private_key, [&fail_op, this, dany_private_key, eddy_private_key]
+                                             (const asset_symbol_type& smt1, const asset_symbol_type& smt2, const asset_symbol_type& smt3) {
+         // "Reset" parameters to default value.
+         smt_set_setup_parameters_operation valid_op = fail_op;
+         valid_op.symbol = smt1;
+         PUSH_OP_TWICE(valid_op, dany_private_key);
 
-      tx.operations.push_back( op );
-      tx.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
-      tx.sign( dany_private_key, db->get_chain_id() );
-      STEEM_REQUIRE_THROW( db->push_transaction( tx, 0 ), fc::exception ); // no SMT
+         // Fail with wrong key.
+         fail_op.symbol = smt2;
+         fail_op.setup_parameters.clear();
+         fail_op.setup_parameters.emplace( smt_param_allow_vesting() );
+         fail_op.setup_parameters.emplace( smt_param_allow_voting() );
+         FAIL_WITH_OP(fail_op, eddy_private_key, fc::exception);
 
-      // create SMT
-      signed_transaction ty;
-      op.symbol = create_smt(ty, "dany", dany_private_key, 3);
+         // Set both explicitly to false.
+         valid_op.setup_parameters.clear();
+         valid_op.setup_parameters.emplace( smt_param_allow_vesting({false}) );
+         valid_op.setup_parameters.emplace( smt_param_allow_voting({false}) );
+         PUSH_OP(valid_op, dany_private_key);
 
-      signed_transaction tz;
-      tz.operations.push_back( op );
-      tz.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
-      tz.sign( dany_private_key, db->get_chain_id() );
+         // Set one to true and another one to false.
+         valid_op.setup_parameters.clear();
+         valid_op.setup_parameters.emplace( smt_param_allow_vesting() );
+         PUSH_OP(valid_op, dany_private_key);
 
-      db->push_transaction( tz, 0 );
-
-      db->push_transaction( tz, database::skip_transaction_dupe_check );
-
-      signed_transaction tx1;
-
-      op.setup_parameters.clear();
-      op.setup_parameters.emplace( smt_param_allow_vesting() );
-      op.setup_parameters.emplace( smt_param_allow_voting() );
-      tx1.operations.push_back( op );
-      tx1.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
-      tx1.sign( eddy_private_key, db->get_chain_id() );
-
-      STEEM_REQUIRE_THROW( db->push_transaction( tx1, 0 ), fc::exception ); // wrong private key
-
-      signed_transaction tx2;
-
-      op.setup_parameters.clear();
-      op.setup_parameters.emplace( smt_param_allow_vesting({false}) );
-      op.setup_parameters.emplace( smt_param_allow_voting({false}) );
-      tx2.operations.push_back( op );
-      tx2.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
-      tx2.sign( dany_private_key, db->get_chain_id() );
-
-      db->push_transaction( tx2, 0 );
-
-      signed_transaction tx3;
-
-      op.setup_parameters.clear();
-      op.setup_parameters.emplace( smt_param_allow_vesting() );
-      tx3.operations.push_back( op );
-      tx3.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
-      tx3.sign( dany_private_key, db->get_chain_id() );
-
-      db->push_transaction( tx3, 0 );
-
-      // TODO:
-      // - check applying smt_set_setup_parameters_operation after setup completed
+         // TODO:
+         // - check applying smt_set_setup_parameters_operation after setup completed
+         });
    }
    FC_LOG_AND_RETHROW()
 }


### PR DESCRIPTION
Implemented testing scenarios of smt creation as described in issue 1653. Modified existing SMT operation tests to use created scenarios. #1653