### PR TITLE
SMT support in supply checks

### DIFF
--- a/libraries/chain/include/steem/chain/database.hpp
+++ b/libraries/chain/include/steem/chain/database.hpp
@@ -438,7 +438,7 @@ namespace steem { namespace chain {
 #ifdef STEEM_ENABLE_SMT
          ///Smart Media Tokens related methods
          ///@{
-
+         void validate_smt_invariants()const;
          /**
           * @return a list of available NAIs.
          */

--- a/libraries/chain/include/steem/chain/smt_objects/smt_token_object.hpp
+++ b/libraries/chain/include/steem/chain/smt_objects/smt_token_object.hpp
@@ -37,9 +37,11 @@ public:
    account_name_type control_account;
    smt_phase         phase = smt_phase::account_elevated;
 
+   share_type        current_supply = 0;
+
    /// set_setup_parameters
-   bool                 allow_voting = false;
-   bool                 allow_vesting = false;
+   bool              allow_voting = false;
+   bool              allow_vesting = false;
 
    /// set_runtime_parameters
    uint32_t cashout_window_seconds = 0;

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -608,11 +608,12 @@ asset_symbol_type smt_database_fixture::create_smt( signed_transaction& tx, cons
 
    try
    {
-      set_price_feed( price( ASSET( "1.000 TBD" ), ASSET( "1.000 TESTS" ) ) );
-
       fund( account_name, 10 * 1000 * 1000 );
-      convert( account_name, ASSET( "5000.000 TESTS" ) );
+      generate_block();
 
+      set_price_feed( price( ASSET( "1.000 TBD" ), ASSET( "1.000 TESTS" ) ) );
+      convert( account_name, ASSET( "5000.000 TESTS" ) );
+      
       // The list of available nais is not dependent on SMT desired precision (token_decimal_places).
       auto available_nais =  db->get_smt_next_identifier();
       FC_ASSERT( available_nais.size() > 0, "No available nai returned by get_smt_next_identifier." );
@@ -628,6 +629,8 @@ asset_symbol_type smt_database_fixture::create_smt( signed_transaction& tx, cons
       tx.sign( key, db->get_chain_id() );
 
       db->push_transaction( tx, 0 );
+
+      generate_block();      
    }
    FC_LOG_AND_RETHROW();
 

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -689,9 +689,10 @@ void smt_database_fixture::create_smt_3( const char* control_account_name, const
 
    try
    {
-      set_price_feed( price( ASSET( "1.000 TBD" ), ASSET( "1.000 TESTS" ) ) );
-
       fund( control_account_name, 10 * 1000 * 1000 );
+      generate_block();
+
+      set_price_feed( price( ASSET( "1.000 TBD" ), ASSET( "1.000 TESTS" ) ) );
       convert( control_account_name, ASSET( "5000.000 TESTS" ) );
 
       set_create_op(&op0, control_account_name, token_name + "0", 0);
@@ -705,6 +706,8 @@ void smt_database_fixture::create_smt_3( const char* control_account_name, const
       tx.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
       tx.sign( key, db->get_chain_id() );
       db->push_transaction( tx, 0 );
+
+      generate_block();
 
       followUpOps(op0.symbol, op1.symbol, op2.symbol);
    }

--- a/tests/tests/smt_tests.cpp
+++ b/tests/tests/smt_tests.cpp
@@ -600,16 +600,22 @@ BOOST_AUTO_TEST_CASE( smt_transfer_apply )
    {
       ACTORS( (alice)(bob) )
 
+      generate_block();
+
       // Create SMT.
       signed_transaction tx, ty;
       asset_symbol_type alice_symbol = create_smt(tx, "alice", alice_private_key, 0);
       asset_symbol_type bob_symbol = create_smt(ty, "bob", bob_private_key, 1);
 
       // Give some SMT to creators.
-      const account_object& alice_account = db->get_account("alice");
-      db->adjust_balance(alice_account, asset(100, alice_symbol));
-      const account_object& bob_account = db->get_account("bob");
-      db->adjust_balance(bob_account, asset(110, bob_symbol));
+      asset alice_symbol_supply( 100, alice_symbol );
+      db->adjust_supply( alice_symbol_supply );
+      const account_object& alice_account = db->get_account( "alice" );
+      db->adjust_balance( alice_account, alice_symbol_supply );
+      asset bob_symbol_supply( 110, bob_symbol );
+      db->adjust_supply( bob_symbol_supply );
+      const account_object& bob_account = db->get_account( "bob" );
+      db->adjust_balance( bob_account, bob_symbol_supply );
 
       // Check pre-tranfer amounts.
       FC_ASSERT( db->get_balance( "alice", alice_symbol ).amount == 100, "SMT balance adjusting error" );
@@ -626,6 +632,8 @@ BOOST_AUTO_TEST_CASE( smt_transfer_apply )
       FC_ASSERT( db->get_balance( "alice", bob_symbol ).amount == 50, "SMT transfer error" );
       FC_ASSERT( db->get_balance( "bob", alice_symbol ).amount == 20, "SMT transfer error" );
       FC_ASSERT( db->get_balance( "bob", bob_symbol ).amount == 60, "SMT transfer error" );
+
+      db->validate_smt_invariants();
    }
    FC_LOG_AND_RETHROW()   
 }


### PR DESCRIPTION
Partial implementation of validate_smt_invariants. Extended smt tests with supply checks. Removed a piece of no longer necessary code #1515