### PR TITLE
1915 init hardforks overrun

### DIFF
--- a/libraries/protocol/hardfork.d/0-preamble.hf
+++ b/libraries/protocol/hardfork.d/0-preamble.hf
@@ -15,5 +15,5 @@
 #ifdef IS_TEST_NET
 #define STEEM_NUM_HARDFORKS 21
 #else
-#define STEEM_NUM_HARDFORKS 19
+#define STEEM_NUM_HARDFORKS 20
 #endif

--- a/libraries/protocol/include/steem/protocol/config.hpp
+++ b/libraries/protocol/include/steem/protocol/config.hpp
@@ -39,7 +39,7 @@
 
 #else // IS LIVE STEEM NETWORK
 
-#define STEEM_BLOCKCHAIN_VERSION              ( version(0, 19, 4) )
+#define STEEM_BLOCKCHAIN_VERSION              ( version(0, 20, 4) )
 
 #define STEEM_INIT_PUBLIC_KEY_STR             "STM8GC13uCZbP44HzMLV6zPZGwVQ8Nt4Kji8PapsPiNq1BK153XTX"
 #define STEEM_CHAIN_ID_NAME ""


### PR DESCRIPTION
Issue #1915 fix of the crash.
@mvandeberg I have doubts related to STEEM_BLOCKCHAIN_VERSION change needed to satisfy one of FC_ASSERTs.
If this blockchain version shall be not changed, I propose rather change _hardfork_times and _hardfork_versions members to std::vectors, having just pushed all needed items, having bigger size than STEEM_NUM_HARDFORKS. 