### PR TITLE
Regenerate node private key when empty key is passed to set_advanced_node_parameters

### DIFF
--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -4448,7 +4448,10 @@ namespace graphene { namespace net {
           ilog( "Loaded configuration from file ${filename}", ("filename", configuration_file_name ) );
 
           if( _node_configuration.private_key == fc::ecc::private_key() )
+          {
+            ilog( "generating new private key for this node" );
             _node_configuration.private_key = fc::ecc::private_key::generate();
+          }
 
           node_configuration_loaded = true;
         }
@@ -4997,8 +5000,15 @@ namespace graphene { namespace net {
     void node_impl::set_advanced_node_parameters(const fc::variant_object& params)
     {
       VERIFY_CORRECT_THREAD();
+      ilog( "set_advanced_node_parameters ${params}", ("params", params) );
 
       fc::from_variant( params, _node_configuration );
+
+      if( _node_configuration.private_key == fc::ecc::private_key() )
+      {
+         ilog( "generating new private key for this node" );
+         _node_configuration.private_key = fc::ecc::private_key::generate();
+      }
 
       if( _node_configuration.desired_number_of_connections > _node_configuration.maximum_number_of_connections )
       {


### PR DESCRIPTION
Issue is originally relevant to #1690