### PR TITLE
Add config for fullnode ops whitelisting to develop/appbase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -219,6 +219,7 @@ ADD doc/seednodes.txt /etc/steemd/seednodes.txt
 # the following adds lots of logging info to stdout
 ADD contrib/config-for-docker.ini /etc/steemd/config.ini
 ADD contrib/fullnode.config.ini /etc/steemd/fullnode.config.ini
+ADD contrib/fullnode.opswhitelist.config.ini /etc/steemd/fullnode.opswhitelist.config.ini
 ADD contrib/config-for-broadcaster.ini /etc/steemd/config-for-broadcaster.ini
 ADD contrib/config-for-ahnode.ini /etc/steemd/config-for-ahnode.ini
 

--- a/contrib/fullnode.opswhitelist.config.ini
+++ b/contrib/fullnode.opswhitelist.config.ini
@@ -9,15 +9,15 @@ log-logger = {"name":"default","level":"debug","appender":"stderr"}
 log-logger = {"name":"p2p","level":"info","appender":"stderr"}
 
 # Plugin(s) to enable, may be specified multiple times
-plugin = webserver p2p json_rpc witness account_by_key tags follow market_history
+plugin = webserver p2p json_rpc witness account_by_key tags follow market_history account_history
 
-plugin = database_api account_by_key_api network_broadcast_api tags_api follow_api market_history_api witness_api condenser_api
+plugin = database_api account_by_key_api network_broadcast_api tags_api follow_api market_history_api witness_api condenser_api account_history_api
 
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times
 # account-history-track-account-range =
 
 # Defines a list of operations which will be explicitly logged.
-# account-history-whitelist-ops = transfer_operation transfer_to_vesting_operation withdraw_vesting_operation interest_operation transfer_to_savings_operation transfer_from_savings_operation cancel_transfer_from_savings_operation escrow_transfer_operation escrow_approve_operation escrow_dispute_operation escrow_release_operation fill_convert_request_operation fill_order_operation claim_reward_balance_operation author_reward_operation curation_reward_operation fill_vesting_withdraw_operation fill_transfer_from_savings_operation delegate_vesting_shares_operation return_vesting_delegation_operation comment_benefactor_reward_operation
+account-history-whitelist-ops = transfer_operation transfer_to_vesting_operation withdraw_vesting_operation interest_operation transfer_to_savings_operation transfer_from_savings_operation cancel_transfer_from_savings_operation escrow_transfer_operation escrow_approve_operation escrow_dispute_operation escrow_release_operation fill_convert_request_operation fill_order_operation claim_reward_balance_operation author_reward_operation curation_reward_operation fill_vesting_withdraw_operation fill_transfer_from_savings_operation delegate_vesting_shares_operation return_vesting_delegation_operation comment_benefactor_reward_operation
 
 # Defines a list of operations which will be explicitly ignored.
 # account-history-blacklist-ops =

--- a/contrib/startpaassteemd.sh
+++ b/contrib/startpaassteemd.sh
@@ -112,6 +112,9 @@ if [[ $? -ne 0 ]]; then
   fi
 fi
 
+# for appbase tags plugin loading
+ARGS+=" --tags-skip-startup-update"
+
 cd $HOME
 
 if [[ "$SYNC_TO_S3" ]]; then

--- a/contrib/startpaassteemd.sh
+++ b/contrib/startpaassteemd.sh
@@ -59,6 +59,8 @@ if [[ "$IS_BROADCAST_NODE" ]]; then
   cp /etc/steemd/config-for-broadcaster.ini $HOME/config.ini
 elif [[ "$IS_AH_NODE" ]]; then
   cp /etc/steemd/config-for-ahnode.ini $HOME/config.ini
+elif [[ "$IS_OPSWHITELIST_NODE" ]]; then
+  cp /etc/steemd/fullnode.opswhitelist.config.ini $HOME/config.ini
 else
   cp /etc/steemd/fullnode.config.ini $HOME/config.ini
 fi

--- a/contrib/steemd.run
+++ b/contrib/steemd.run
@@ -64,6 +64,8 @@ elif [[ "$IS_BROADCAST_NODE" ]]; then
   cp /etc/steemd/config-for-broadcaster.ini $HOME/config.ini
 elif [[ "$IS_AH_NODE" ]]; then
   cp /etc/steemd/config-for-ahnode.ini $HOME/config.ini
+elif [[ "$IS_OPSWHITELIST_NODE" ]]; then
+  cp /etc/steemd/fullnode.opswhitelist.config.ini $HOME/config.ini
 else
   cp /etc/steemd/config.ini $HOME/config.ini
 fi


### PR DESCRIPTION
This is so we can test anything necessary for condenser in dev but negates the necessity of splitting out account history into separate nodes.