### PR TITLE
fix lbzip2 entry in startup scripts

### DIFF
--- a/contrib/startpaassteemd.sh
+++ b/contrib/startpaassteemd.sh
@@ -83,7 +83,7 @@ if [[ "$USE_RAMDISK" ]]; then
   elif [[ "$IS_AH_NODE" ]]; then
     s3cmd get s3://$S3_BUCKET/ahnode-$VERSION-latest.tar.bz2 - | pbzip2 -m2000dc | tar x --wildcards 'blockchain/block*' -C /mnt/ramdisk 'blockchain/shared*'
   else
-    s3cmd get s3://$S3_BUCKET/blockchain-$VERSION-latest.tar.bz2 - | lbzip2 -dc | tar x --wildcards 'blockchain/block*' -C /mnt/ramdisk 'blockchain/shared*'
+    s3cmd get s3://$S3_BUCKET/blockchain-$VERSION-latest.tar.bz2 - | pbzip2 -m2000dc | tar x --wildcards 'blockchain/block*' -C /mnt/ramdisk 'blockchain/shared*'
   fi
   chown -R steemd:steemd /mnt/ramdisk/blockchain
 else
@@ -92,7 +92,7 @@ else
   elif [[ "$IS_AH_NODE" ]]; then
     s3cmd get s3://$S3_BUCKET/ahnode-$VERSION-latest.tar.bz2 - | pbzip2 -m2000dc | tar x
   else
-    s3cmd get s3://$S3_BUCKET/blockchain-$VERSION-latest.tar.bz2 - | lbzip2 -dc | tar x
+    s3cmd get s3://$S3_BUCKET/blockchain-$VERSION-latest.tar.bz2 - | pbzip2 -m2000dc | tar x
   fi
 fi
 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
This is an artifact from a previous branch, we're using pbzip2 not lbzip2