### PR TITLE
Fix legacy_operations serialization to match non-legacy serialization

### DIFF
--- a/libraries/plugins/apis/condenser_api/CMakeLists.txt
+++ b/libraries/plugins/apis/condenser_api/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library( condenser_api_plugin
              condenser_api.cpp
              condenser_api_plugin.cpp
              condenser_api_legacy_asset.cpp
+             condenser_api_legacy_operations.cpp
              ${HEADERS} )
 
 target_link_libraries( condenser_api_plugin

--- a/libraries/plugins/apis/condenser_api/condenser_api.cpp
+++ b/libraries/plugins/apis/condenser_api/condenser_api.cpp
@@ -1998,5 +1998,3 @@ DEFINE_READ_APIS( condenser_api,
 )
 
 } } } // steem::plugins::condenser_api
-
-STEEM_DEFINE_OPERATION_TYPE( steem::plugins::condenser_api::legacy_operation )

--- a/libraries/plugins/apis/condenser_api/condenser_api_legacy_operations.cpp
+++ b/libraries/plugins/apis/condenser_api/condenser_api_legacy_operations.cpp
@@ -1,0 +1,85 @@
+#include <steem/plugins/condenser_api/condenser_api_legacy_operations.hpp>
+
+#define LEGACY_PREFIX "legacy_"
+#define LEGACY_PREFIX_OFFSET (7)
+
+namespace fc {
+
+std::string name_from_legacy_type( const std::string& type_name )
+{
+   auto start = type_name.find( LEGACY_PREFIX );
+   if( start == std::string::npos )
+   {
+      start = type_name.find_last_of( ':' ) + 1;
+   }
+   else
+   {
+      start += LEGACY_PREFIX_OFFSET;
+   }
+   auto end   = type_name.find_last_of( '_' );
+
+   return type_name.substr( start, end-start );
+}
+
+struct from_operation
+{
+   variant& var;
+   from_operation( variant& dv )
+      : var( dv ) {}
+
+   typedef void result_type;
+   template<typename T> void operator()( const T& v )const
+   {
+      auto name = name_from_legacy_type( fc::get_typename< T >::name() );
+      var = variant( std::make_pair( name, v ) );
+   }
+};
+
+struct get_operation_name
+{
+   string& name;
+   get_operation_name( string& dv )
+      : name( dv ) {}
+
+   typedef void result_type;
+   template< typename T > void operator()( const T& v )const
+   {
+      name = name_from_legacy_type( fc::get_typename< T >::name() );
+   }
+};
+
+void to_variant( const steem::plugins::condenser_api::legacy_operation& var,  fc::variant& vo )
+{
+   var.visit( from_operation( vo ) );
+}
+
+void from_variant( const fc::variant& var, steem::plugins::condenser_api::legacy_operation& vo )
+{
+   static std::map<string,uint32_t> to_tag = []()
+   {
+      std::map<string,uint32_t> name_map;
+      for( int i = 0; i < steem::plugins::condenser_api::legacy_operation::count(); ++i )
+      {
+         steem::plugins::condenser_api::legacy_operation tmp;
+         tmp.set_which(i);
+         string n;
+         tmp.visit( get_operation_name(n) );
+         name_map[n] = i;
+      }
+      return name_map;
+   }();
+
+   auto ar = var.get_array();
+   if( ar.size() < 2 ) return;
+   if( ar[0].is_uint64() )
+      vo.set_which( ar[0].as_uint64() );
+   else
+   {
+      auto itr = to_tag.find(ar[0].as_string());
+      FC_ASSERT( itr != to_tag.end(), "Invalid operation name: ${n}", ("n", ar[0]) );
+      vo.set_which( to_tag[ar[0].as_string()] );
+   }
+      vo.visit( fc::to_static_variant( ar[1] ) );
+}
+
+} // fc

--- a/libraries/plugins/apis/condenser_api/include/steem/plugins/condenser_api/condenser_api_legacy_operations.hpp
+++ b/libraries/plugins/apis/condenser_api/include/steem/plugins/condenser_api/condenser_api_legacy_operations.hpp
@@ -47,7 +47,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset quote;
    };
 
-   struct legacy_account_create_operation : public base_operation
+   struct legacy_account_create_operation
    {
       legacy_account_create_operation() {}
       legacy_account_create_operation( const account_create_operation& op ) :
@@ -71,7 +71,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       string            json_metadata;
    };
 
-   struct legacy_account_create_with_delegation_operation : public base_operation
+   struct legacy_account_create_with_delegation_operation
    {
       legacy_account_create_with_delegation_operation() {}
       legacy_account_create_with_delegation_operation( const account_create_with_delegation_operation op ) :
@@ -101,7 +101,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       extensions_type   extensions;
    };
 
-   struct legacy_comment_options_operation : public base_operation
+   struct legacy_comment_options_operation
    {
       legacy_comment_options_operation() {}
       legacy_comment_options_operation( const comment_options_operation& op ) :
@@ -125,7 +125,7 @@ namespace steem { namespace plugins { namespace condenser_api {
    };
 
 
-   struct legacy_transfer_operation : public base_operation
+   struct legacy_transfer_operation
    {
       legacy_transfer_operation() {}
       legacy_transfer_operation( const transfer_operation& op ) :
@@ -141,7 +141,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       string            memo;
    };
 
-   struct legacy_escrow_transfer_operation : public base_operation
+   struct legacy_escrow_transfer_operation
    {
       legacy_escrow_transfer_operation() {}
       legacy_escrow_transfer_operation( const escrow_transfer_operation& op ) :
@@ -172,7 +172,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       string            json_meta;
    };
 
-   struct legacy_escrow_release_operation : public base_operation
+   struct legacy_escrow_release_operation
    {
       legacy_escrow_release_operation() {}
       legacy_escrow_release_operation( const escrow_release_operation& op ) :
@@ -197,7 +197,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      steem_amount;
    };
 
-   struct legacy_transfer_to_vesting_operation : public base_operation
+   struct legacy_transfer_to_vesting_operation
    {
       legacy_transfer_to_vesting_operation() {}
       legacy_transfer_to_vesting_operation( const transfer_to_vesting_operation& op ) :
@@ -211,7 +211,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      amount;
    };
 
-   struct legacy_withdraw_vesting_operation : public base_operation
+   struct legacy_withdraw_vesting_operation
    {
       legacy_withdraw_vesting_operation() {}
       legacy_withdraw_vesting_operation( const withdraw_vesting_operation& op ) :
@@ -223,7 +223,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset             vesting_shares;
    };
 
-   struct legacy_witness_update_operation : public base_operation
+   struct legacy_witness_update_operation
    {
       legacy_witness_update_operation() {}
       legacy_witness_update_operation( const witness_update_operation& op ) :
@@ -244,7 +244,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset            fee;
    };
 
-   struct legacy_feed_publish_operation : public base_operation
+   struct legacy_feed_publish_operation
    {
       legacy_feed_publish_operation() {}
       legacy_feed_publish_operation( const feed_publish_operation& op ) :
@@ -256,7 +256,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_price      exchange_rate;
    };
 
-   struct legacy_convert_operation : public base_operation
+   struct legacy_convert_operation
    {
       legacy_convert_operation() {}
       legacy_convert_operation( const convert_operation& op ) :
@@ -270,7 +270,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      amount;
    };
 
-   struct legacy_limit_order_create_operation : public base_operation
+   struct legacy_limit_order_create_operation
    {
       legacy_limit_order_create_operation() {}
       legacy_limit_order_create_operation( const limit_order_create_operation& op ) :
@@ -290,7 +290,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       time_point_sec    expiration;
    };
 
-   struct legacy_limit_order_create2_operation : public base_operation
+   struct legacy_limit_order_create2_operation
    {
       legacy_limit_order_create2_operation() {}
       legacy_limit_order_create2_operation( const limit_order_create2_operation& op ) :
@@ -310,7 +310,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       time_point_sec    expiration;
    };
 
-   struct legacy_transfer_to_savings_operation : public base_operation
+   struct legacy_transfer_to_savings_operation
    {
       legacy_transfer_to_savings_operation() {}
       legacy_transfer_to_savings_operation( const transfer_to_savings_operation& op ) :
@@ -326,7 +326,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       string            memo;
    };
 
-   struct legacy_transfer_from_savings_operation : public base_operation
+   struct legacy_transfer_from_savings_operation
    {
       legacy_transfer_from_savings_operation() {}
       legacy_transfer_from_savings_operation( const transfer_from_savings_operation& op ) :
@@ -344,7 +344,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       string            memo;
    };
 
-   struct legacy_claim_reward_balance_operation : public base_operation
+   struct legacy_claim_reward_balance_operation
    {
       legacy_claim_reward_balance_operation() {}
       legacy_claim_reward_balance_operation( const claim_reward_balance_operation& op ) :
@@ -360,7 +360,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      reward_vests;
    };
 
-   struct legacy_delegate_vesting_shares_operation : public base_operation
+   struct legacy_delegate_vesting_shares_operation
    {
       legacy_delegate_vesting_shares_operation() {}
       legacy_delegate_vesting_shares_operation( const delegate_vesting_shares_operation& op ) :
@@ -374,7 +374,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      vesting_shares;
    };
 
-   struct legacy_author_reward_operation : public base_operation
+   struct legacy_author_reward_operation
    {
       legacy_author_reward_operation() {}
       legacy_author_reward_operation( const author_reward_operation& op ) :
@@ -392,7 +392,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      vesting_payout;
    };
 
-   struct legacy_curation_reward_operation : public base_operation
+   struct legacy_curation_reward_operation
    {
       legacy_curation_reward_operation() {}
       legacy_curation_reward_operation( const curation_reward_operation& op ) :
@@ -408,7 +408,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       string            comment_permlink;
    };
 
-   struct legacy_comment_reward_operation : public base_operation
+   struct legacy_comment_reward_operation
    {
       legacy_comment_reward_operation() {}
       legacy_comment_reward_operation( const comment_reward_operation& op ) :
@@ -422,7 +422,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      payout;
    };
 
-   struct legacy_liquidity_reward_operation : public base_operation
+   struct legacy_liquidity_reward_operation
    {
       legacy_liquidity_reward_operation() {}
       legacy_liquidity_reward_operation( const liquidity_reward_operation& op ) :
@@ -434,7 +434,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      payout;
    };
 
-   struct legacy_interest_operation : public base_operation
+   struct legacy_interest_operation
    {
       legacy_interest_operation() {}
       legacy_interest_operation( const interest_operation& op ) :
@@ -446,7 +446,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      interest;
    };
 
-   struct legacy_fill_convert_request_operation : public base_operation
+   struct legacy_fill_convert_request_operation
    {
       legacy_fill_convert_request_operation() {}
       legacy_fill_convert_request_operation( const fill_convert_request_operation& op ) :
@@ -462,7 +462,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      amount_out;
    };
 
-   struct legacy_fill_vesting_withdraw_operation : public base_operation
+   struct legacy_fill_vesting_withdraw_operation
    {
       legacy_fill_vesting_withdraw_operation() {}
       legacy_fill_vesting_withdraw_operation( const fill_vesting_withdraw_operation& op ) :
@@ -478,7 +478,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      deposited;
    };
 
-   struct legacy_fill_order_operation : public base_operation
+   struct legacy_fill_order_operation
    {
       legacy_fill_order_operation() {}
       legacy_fill_order_operation( const fill_order_operation& op ) :
@@ -498,7 +498,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      open_pays;
    };
 
-   struct legacy_fill_transfer_from_savings_operation : public base_operation
+   struct legacy_fill_transfer_from_savings_operation
    {
       legacy_fill_transfer_from_savings_operation() {}
       legacy_fill_transfer_from_savings_operation( const fill_transfer_from_savings_operation& op ) :
@@ -516,7 +516,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       string            memo;
    };
 
-   struct legacy_return_vesting_delegation_operation : public base_operation
+   struct legacy_return_vesting_delegation_operation
    {
       legacy_return_vesting_delegation_operation() {}
       legacy_return_vesting_delegation_operation( const return_vesting_delegation_operation& op ) :
@@ -528,7 +528,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      vesting_shares;
    };
 
-   struct legacy_comment_benefactor_reward_operation : public base_operation
+   struct legacy_comment_benefactor_reward_operation
    {
       legacy_comment_benefactor_reward_operation() {}
       legacy_comment_benefactor_reward_operation( const comment_benefactor_reward_operation& op ) :
@@ -544,7 +544,7 @@ namespace steem { namespace plugins { namespace condenser_api {
       legacy_asset      reward;
    };
 
-   struct legacy_producer_reward_operation : public base_operation
+   struct legacy_producer_reward_operation
    {
       legacy_producer_reward_operation() {}
       legacy_producer_reward_operation( const producer_reward_operation& op ) :
@@ -837,6 +837,13 @@ namespace steem { namespace plugins { namespace condenser_api {
 
 } } } // steem::plugins::condenser_api
 
+namespace fc {
+
+void to_variant( const steem::plugins::condenser_api::legacy_operation&, fc::variant& );
+void from_variant( const fc::variant&, steem::plugins::condenser_api::legacy_operation& );
+
+}
+
 FC_REFLECT( steem::plugins::condenser_api::legacy_price, (base)(quote) )
 FC_REFLECT( steem::plugins::condenser_api::legacy_transfer_to_savings_operation, (from)(to)(amount)(memo) )
 FC_REFLECT( steem::plugins::condenser_api::legacy_transfer_from_savings_operation, (from)(request_id)(to)(amount)(memo) )
@@ -889,5 +896,4 @@ FC_REFLECT( steem::plugins::condenser_api::legacy_return_vesting_delegation_oper
 FC_REFLECT( steem::plugins::condenser_api::legacy_comment_benefactor_reward_operation, (benefactor)(author)(permlink)(reward) )
 FC_REFLECT( steem::plugins::condenser_api::legacy_producer_reward_operation, (producer)(vesting_shares) )
 
-STEEM_DECLARE_OPERATION_TYPE( steem::plugins::condenser_api::legacy_operation )
 FC_REFLECT_TYPENAME( steem::plugins::condenser_api::legacy_operation )


### PR DESCRIPTION
Closes #2045

As stated in the issue #2038 was not sufficient. This was tested against Condenser and works.