### PR TITLE
exchangequickstart.md - Update RAM requirements

### DIFF
--- a/doc/exchangequickstart.md
+++ b/doc/exchangequickstart.md
@@ -1,7 +1,7 @@
 Exchange Quickstart
 -------------------
 
-System Requirements: A dedicated server or virtual machine with a minimum of 16GB of RAM, and at least 50GB of fast local SSD storage. STEEM is one of the most active blockchains in the world and handles an incredibly large amount of transactions per second, as such, it requires fast storage to run efficiently.
+System Requirements: A dedicated server or virtual machine with a minimum of 24GB of RAM (recommended 32GB), and at least 50GB of fast local SSD storage. STEEM is one of the most active blockchains in the world and handles an incredibly large amount of transactions per second, as such, it requires fast storage to run efficiently.
 
 We recommend using docker to both build and run STEEM for exchanges. Docker is the world's leading containerization platform and using it guarantees that your build and run environment is identical to what our developers use. You can still build from source and you can keep both blockchain data and wallet data outside of the docker container. The instructions below will show you how to do this in just a few easy steps.
 


### PR DESCRIPTION
The RAM requirements for an exchange node have increased. Exchange nodes should have at least 24GB of RAM, recommended 32GB.