### PR TITLE
Updated mem settings and info to reflect current state of Steem

### DIFF
--- a/contrib/config-for-broadcaster.ini
+++ b/contrib/config-for-broadcaster.ini
@@ -1,6 +1,6 @@
 # this will need to increase depending on which plugins/apis you use
-# 16 GB should be sufficient for a consensus node
-shared-file-size = 24G
+# 40 GB should be sufficient for a consensus node
+shared-file-size = 40G
 
 # Endpoint for P2P node to listen on
 # p2p-endpoint =

--- a/contrib/config-for-docker.ini
+++ b/contrib/config-for-docker.ini
@@ -1,36 +1,36 @@
 # this will need to increase depending on which plugins/apis you use
-# 16 GB should be sufficient for a consensus node
-shared-file-size = 24G
+# 40 GB should be sufficient for a consensus node
+shared-file-size = 40G
 
 # Endpoint for P2P node to listen on
-# p2p-endpoint = 
+# p2p-endpoint =
 
 # Maxmimum number of incoming connections on P2P endpoint
-# p2p-max-connections = 
+# p2p-max-connections =
 
 # P2P nodes to connect to on startup (may specify multiple times)
-# seed-node = 
+# seed-node =
 
 # Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.
-# checkpoint = 
+# checkpoint =
 
 # Endpoint for websocket RPC to listen on
-# rpc-endpoint = 
+# rpc-endpoint =
 
 # Endpoint for TLS websocket RPC to listen on
-# rpc-tls-endpoint = 
+# rpc-tls-endpoint =
 
 # The TLS certificate file for this server
-# server-pem = 
+# server-pem =
 
 # Password for this certificate
-# server-pem-password = 
+# server-pem-password =
 
 # Block signing key to use for init witnesses, overrides genesis file
-# dbg-init-key = 
+# dbg-init-key =
 
 # API user specification, may be specified multiple times
-# api-user = 
+# api-user =
 
 # Set an API to be publicly available, may be specified multiple times
 public-api = database_api login_api
@@ -45,13 +45,13 @@ bcd-trigger = [[0,10],[85,300]]
 # track-account-range =
 
 # Ignore posting operations, only track transfers and account updates
-# filter-posting-ops = 
+# filter-posting-ops =
 
 # Database edits to apply on startup (may specify multiple times)
-# edit-script = 
+# edit-script =
 
 # RPC endpoint of a trusted validating node (required)
-# trusted-node = 
+# trusted-node =
 
 # Set the maximum size of cached feed for an account
 follow-max-feed-size = 500
@@ -63,7 +63,7 @@ bucket-size = [15,60,300,3600,86400]
 history-per-size = 5760
 
 # Defines a range of accounts to private messages to/from as a json pair ["from","to"] [from,to)
-# pm-account-range = 
+# pm-account-range =
 
 # Enable block production, even if the chain is stale.
 enable-stale-production = false
@@ -72,25 +72,25 @@ enable-stale-production = false
 required-participation = false
 
 # name of witness controlled by this node (e.g. initwitness )
-# witness = 
+# witness =
 
 # name of miner and its private key (e.g. ["account","WIF PRIVATE KEY"] )
-# miner = 
+# miner =
 
 # Number of threads to use for proof of work mining
-# mining-threads = 
+# mining-threads =
 
 # WIF PRIVATE KEY to be used by one or more witnesses or miners
-# private-key = 
+# private-key =
 
 # Account creation fee to be voted on upon successful POW - Minimum fee is 100.000 STEEM (written as 100000)
-# miner-account-creation-fee = 
+# miner-account-creation-fee =
 
 # Maximum block size (in bytes) to be voted on upon successful POW - Max block size must be between 128 KB and 750 MB
-# miner-maximum-block-size = 
+# miner-maximum-block-size =
 
 # SBD interest rate to be vote on upon successful POW - Default interest rate is 10% (written as 1000)
-# miner-sbd-interest-rate = 
+# miner-sbd-interest-rate =
 
 # declare an appender named "stderr" that writes messages to the console
 [log.console_appender.stderr]

--- a/doc/example_config.ini
+++ b/doc/example_config.ini
@@ -1,6 +1,6 @@
 # this will need to increase depending on which plugins/apis you use
-# 24 GB should be sufficient for a consensus node
-shared-file-size = 24G
+# 40 GB should be sufficient for a consensus node
+shared-file-size = 40G
 
 # Endpoint for P2P node to listen on
 # p2p-endpoint =

--- a/doc/exchangequickstart.md
+++ b/doc/exchangequickstart.md
@@ -1,7 +1,7 @@
 Exchange Quickstart
 -------------------
 
-System Requirements: A dedicated server or virtual machine with a minimum of 16GB of RAM, and at least 50GB of fast local SSD storage. STEEM is one of the most active blockchains in the world and handles an incredibly large amount of transactions per second, as such, it requires fast storage to run efficiently.
+System Requirements: A dedicated server or virtual machine with a minimum of 32GB of RAM, and at least 100GB of fast local SSD storage. STEEM is one of the most active blockchains in the world and handles an incredibly large amount of transactions per second, as such, it requires fast storage to run efficiently.
 
 We recommend using docker to both build and run STEEM for exchanges. Docker is the world's leading containerization platform and using it guarantees that your build and run environment is identical to what our developers use. You can still build from source and you can keep both blockchain data and wallet data outside of the docker container. The instructions below will show you how to do this in just a few easy steps.
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -55,17 +55,17 @@ Set it to at least 25% more than current size.
 
 Provided values are expected to grow significantly over time.
 
-Blockchain data takes over **16GB** of storage space.
+Blockchain data takes over **64GB** of storage space.
 
 #### Full node
-Shared memory file for full node uses over **65GB**
+Shared memory file for full node uses something about **200GB** (depends on exact settings)
 
 #### Exchange node
-Shared memory file for exchange node users over **16GB**
+Shared memory file for exchange node users over **24GB**
 (tracked history for single account)
 
 #### Seed node
-Shared memory file for seed node uses over **5.5GB**
+Shared memory file for seed node uses over **24GB**
 
 #### Other use cases
 Shared memory file size varies, depends on your specific configuration but it is expected to be somewhere between "seed node" and "full node" usage.


### PR DESCRIPTION
Changed default shared memory size to 40GB in config files and updates some docs about mem requirements.
Of course automatic shared memory file resize would be preferred, but this PR could be used as a temporary fix for default docker installations to run out of the box before auto-resize will be included in stable.