### PR TITLE
2nd take on claim_reward_balance2_operation creation

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -2248,6 +2248,9 @@ void database::initialize_evaluators()
    _my->_evaluator_registry.register_evaluator< reset_account_evaluator                  >();
    _my->_evaluator_registry.register_evaluator< set_reset_account_evaluator              >();
    _my->_evaluator_registry.register_evaluator< claim_reward_balance_evaluator           >();
+#ifdef STEEM_ENABLE_SMT
+   _my->_evaluator_registry.register_evaluator< claim_reward_balance2_evaluator          >();
+#endif
    _my->_evaluator_registry.register_evaluator< account_create_with_delegation_evaluator >();
    _my->_evaluator_registry.register_evaluator< delegate_vesting_shares_evaluator        >();
    _my->_evaluator_registry.register_evaluator< witness_set_properties_evaluator         >();
@@ -3544,6 +3547,32 @@ void database::modify_balance( const account_object& a, const asset& delta, bool
    } );
 }
 
+void database::modify_reward_balance( const account_object& a, const asset& delta, bool check_balance )
+{
+   modify( a, [&]( account_object& acnt )
+   {
+      switch( delta.symbol.asset_num )
+      {
+         case STEEM_ASSET_NUM_STEEM:
+            acnt.reward_steem_balance += delta;
+            if( check_balance )
+            {
+               FC_ASSERT( acnt.reward_steem_balance.amount.value >= 0, "Insufficient reward STEEM funds" );
+            }
+            break;
+         case STEEM_ASSET_NUM_SBD:
+            acnt.reward_sbd_balance += delta;
+            if( check_balance )
+            {
+               FC_ASSERT( acnt.reward_sbd_balance.amount.value >= 0, "Insufficient reward SBD funds" );
+            }
+            break;
+         default:
+            FC_ASSERT( false, "invalid symbol" );
+      }
+   });
+}
+
 void database::adjust_balance( const account_object& a, const asset& delta )
 {
    bool check_balance = has_hardfork( STEEM_HARDFORK_0_20__1811 );
@@ -3645,30 +3674,27 @@ void database::adjust_reward_balance( const account_object& a, const asset& delt
       return;
    }
 #endif
-   modify( a, [&]( account_object& acnt )
-   {
-      switch( delta.symbol.asset_num )
-      {
-         case STEEM_ASSET_NUM_STEEM:
-            acnt.reward_steem_balance += delta;
-            if( check_balance )
-            {
-               FC_ASSERT( acnt.reward_steem_balance.amount.value >= 0, "Insufficient reward STEEM funds" );
-            }
-            break;
-         case STEEM_ASSET_NUM_SBD:
-            acnt.reward_sbd_balance += delta;
-            if( check_balance )
-            {
-               FC_ASSERT( acnt.reward_sbd_balance.amount.value >= 0, "Insufficient reward SBD funds" );
-            }
-            break;
-         default:
-            FC_ASSERT( false, "invalid symbol" );
-      }
-   });
+
+   modify_reward_balance(a, delta, check_balance);
 }
 
+void database::adjust_reward_balance( const account_name_type& name, const asset& delta )
+{
+   bool check_balance = has_hardfork( STEEM_HARDFORK_0_20__1811 );
+
+#ifdef STEEM_ENABLE_SMT
+   // No account object modification for SMT balance, hence separate handling here.
+   // Note that SMT related code, being post-20-hf needs no hf-guard to do balance checks.
+   if( delta.symbol.space() == asset_symbol_type::smt_nai_space )
+   {
+      adjust_smt_balance< account_rewards_balance_object >( name, delta, false/*check_account*/ );
+      return;
+   }
+#endif
+
+   const auto& a = get_account( name );
+   modify_reward_balance(a, delta, check_balance);
+}
 
 void database::adjust_supply( const asset& delta, bool adjust_vesting )
 {

--- a/libraries/chain/include/steem/chain/database.hpp
+++ b/libraries/chain/include/steem/chain/database.hpp
@@ -313,6 +313,7 @@ namespace steem { namespace chain {
          void        adjust_balance( const account_name_type& name, const asset& delta );
          void        adjust_savings_balance( const account_object& a, const asset& delta );
          void        adjust_reward_balance( const account_object& a, const asset& delta );
+         void        adjust_reward_balance( const account_name_type& name, const asset& delta );
          void        adjust_supply( const asset& delta, bool adjust_vesting = false );
          void        adjust_rshares2( const comment_object& comment, fc::uint128_t old_rshares2, fc::uint128_t new_rshares2 );
          void        update_owner_authority( const account_object& account, const authority& owner_authority );
@@ -488,6 +489,7 @@ namespace steem { namespace chain {
          void adjust_smt_balance( const account_name_type& name, const asset& delta, bool check_account );
 #endif
          void modify_balance( const account_object& a, const asset& delta, bool check_balance );
+         void modify_reward_balance( const account_object& a, const asset& delta, bool check_balance );
 
          std::unique_ptr< database_impl > _my;
 

--- a/libraries/chain/include/steem/chain/steem_evaluator.hpp
+++ b/libraries/chain/include/steem/chain/steem_evaluator.hpp
@@ -49,6 +49,9 @@ STEEM_DEFINE_EVALUATOR( decline_voting_rights )
 STEEM_DEFINE_EVALUATOR( reset_account )
 STEEM_DEFINE_EVALUATOR( set_reset_account )
 STEEM_DEFINE_EVALUATOR( claim_reward_balance )
+#ifdef STEEM_ENABLE_SMT
+STEEM_DEFINE_EVALUATOR( claim_reward_balance2 )
+#endif
 STEEM_DEFINE_EVALUATOR( delegate_vesting_shares )
 STEEM_DEFINE_EVALUATOR( witness_set_properties )
 #ifdef STEEM_ENABLE_SMT

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -2213,7 +2213,7 @@ void claim_reward_balance2_evaluator::do_apply( const claim_reward_balance2_oper
             FC_ASSERT( a != nullptr, "Could NOT find account ${a}", ("a", op.account) );
          }
 
-         if( is_asset_type( token, VESTS_SYMBOL) ) // VESTS here
+         if( token.symbol == VESTS_SYMBOL)
          {
             FC_ASSERT( token <= a->reward_vesting_balance, "Cannot claim that much VESTS. Claim: ${c} Actual: ${a}",
                ("c", token)("a", a->reward_vesting_balance) );   
@@ -2243,7 +2243,7 @@ void claim_reward_balance2_evaluator::do_apply( const claim_reward_balance2_oper
 
             _db.adjust_proxied_witness_votes( *a, token.amount );
          }
-         else // STEEM & SBD here
+         else if( token.symbol == STEEM_SYMBOL || token.symbol == SBD_SYMBOL )
          {
             FC_ASSERT( is_asset_type( token, STEEM_SYMBOL ) == false || token <= a->reward_steem_balance,
                        "Cannot claim that much STEEM. Claim: ${c} Actual: ${a}", ("c", token)("a", a->reward_steem_balance) );
@@ -2252,6 +2252,8 @@ void claim_reward_balance2_evaluator::do_apply( const claim_reward_balance2_oper
             _db.adjust_reward_balance( *a, -token );
             _db.adjust_balance( *a, token );
          }
+         else
+            FC_ASSERT( false, "Unknown asset symbol" );
       } // non-SMT token
    } // for( const auto& token : op.reward_tokens )
 }

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -2197,9 +2197,8 @@ void claim_reward_balance2_evaluator::do_apply( const claim_reward_balance2_oper
 {
    const account_object* a = nullptr; // Lazily initialized below because it may turn out unnecessary.
 
-   for( const auto& token_entry : op.reward_tokens )
+   for( const asset& token : op.reward_tokens )
    {
-      const asset& token = token_entry.second;
       if( token.symbol.space() == asset_symbol_type::smt_nai_space )
       {
          _db.adjust_reward_balance( op.account, -token );

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -2199,6 +2199,9 @@ void claim_reward_balance2_evaluator::do_apply( const claim_reward_balance2_oper
 
    for( const asset& token : op.reward_tokens )
    {
+      if( token.amount == 0 )
+         continue;
+         
       if( token.symbol.space() == asset_symbol_type::smt_nai_space )
       {
          _db.adjust_reward_balance( op.account, -token );

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -2192,6 +2192,72 @@ void claim_reward_balance_evaluator::do_apply( const claim_reward_balance_operat
    _db.adjust_proxied_witness_votes( acnt, op.reward_vests.amount );
 }
 
+#ifdef STEEM_ENABLE_SMT
+void claim_reward_balance2_evaluator::do_apply( const claim_reward_balance2_operation& op )
+{
+   const account_object* a = nullptr; // Lazily initialized below because it may turn out unnecessary.
+
+   for( const auto& token_entry : op.reward_tokens )
+   {
+      const asset& token = token_entry.second;
+      if( token.symbol.space() == asset_symbol_type::smt_nai_space )
+      {
+         _db.adjust_reward_balance( op.account, -token );
+         _db.adjust_balance( op.account, token );
+      }
+      else
+      {
+         // Lazy init here.
+         if( a == nullptr )
+         {
+            a = _db.find_account( op.account );
+            FC_ASSERT( a != nullptr, "Could NOT find account ${a}", ("a", op.account) );
+         }
+
+         if( is_asset_type( token, VESTS_SYMBOL) ) // VESTS here
+         {
+            FC_ASSERT( token <= a->reward_vesting_balance, "Cannot claim that much VESTS. Claim: ${c} Actual: ${a}",
+               ("c", token)("a", a->reward_vesting_balance) );   
+
+            asset reward_vesting_steem_to_move = asset( 0, STEEM_SYMBOL );
+            if( token == a->reward_vesting_balance )
+               reward_vesting_steem_to_move = a->reward_vesting_steem;
+            else
+               reward_vesting_steem_to_move = asset( ( ( uint128_t( token.amount.value ) * uint128_t( a->reward_vesting_steem.amount.value ) )
+                  / uint128_t( a->reward_vesting_balance.amount.value ) ).to_uint64(), STEEM_SYMBOL );
+
+            _db.modify( *a, [&]( account_object& a )
+            {
+               a.vesting_shares += token;
+               a.reward_vesting_balance -= token;
+               a.reward_vesting_steem -= reward_vesting_steem_to_move;
+            });
+
+            _db.modify( _db.get_dynamic_global_properties(), [&]( dynamic_global_property_object& gpo )
+            {
+               gpo.total_vesting_shares += token;
+               gpo.total_vesting_fund_steem += reward_vesting_steem_to_move;
+
+               gpo.pending_rewarded_vesting_shares -= token;
+               gpo.pending_rewarded_vesting_steem -= reward_vesting_steem_to_move;
+            });
+
+            _db.adjust_proxied_witness_votes( *a, token.amount );
+         }
+         else // STEEM & SBD here
+         {
+            FC_ASSERT( is_asset_type( token, STEEM_SYMBOL ) == false || token <= a->reward_steem_balance,
+                       "Cannot claim that much STEEM. Claim: ${c} Actual: ${a}", ("c", token)("a", a->reward_steem_balance) );
+            FC_ASSERT( is_asset_type( token, SBD_SYMBOL ) == false || token <= a->reward_sbd_balance,
+                       "Cannot claim that much SBD. Claim: ${c} Actual: ${a}", ("c", token)("a", a->reward_sbd_balance) );
+            _db.adjust_reward_balance( *a, -token );
+            _db.adjust_balance( *a, token );
+         }
+      } // non-SMT token
+   } // for( const auto& token : op.reward_tokens )
+}
+#endif
+
 void delegate_vesting_shares_evaluator::do_apply( const delegate_vesting_shares_operation& op )
 {
    const auto& delegator = _db.get_account( op.delegator );

--- a/libraries/protocol/include/steem/protocol/asset.hpp
+++ b/libraries/protocol/include/steem/protocol/asset.hpp
@@ -85,22 +85,6 @@ namespace steem { namespace protocol {
       }
    };
 
-   /** Helper comparator facilitating asset (or asset_symbol_type)
-    *  storage sorted by symbol's nai.
-    */
-   struct nai_less
-   {
-      bool operator()( const asset& a, const asset& b )const
-      {
-         return a.symbol.to_nai() < b.symbol.to_nai();
-      }
-
-      bool operator()( const asset_symbol_type& a, const asset_symbol_type& b )const
-      {
-         return a.to_nai() < b.to_nai();
-      }
-   };
-
    /** Represents quotation of the relative value of asset against another asset.
        Similar to 'currency pair' used to determine value of currencies.
 

--- a/libraries/protocol/include/steem/protocol/asset.hpp
+++ b/libraries/protocol/include/steem/protocol/asset.hpp
@@ -85,6 +85,22 @@ namespace steem { namespace protocol {
       }
    };
 
+   /** Helper comparator facilitating asset (or asset_symbol_type)
+    *  storage sorted by symbol's nai.
+    */
+   struct nai_less
+   {
+      bool operator()( const asset& a, const asset& b )const
+      {
+         return a.symbol.to_nai() < b.symbol.to_nai();
+      }
+
+      bool operator()( const asset_symbol_type& a, const asset_symbol_type& b )const
+      {
+         return a.to_nai() < b.to_nai();
+      }
+   };
+
    /** Represents quotation of the relative value of asset against another asset.
        Similar to 'currency pair' used to determine value of currencies.
 

--- a/libraries/protocol/include/steem/protocol/operations.hpp
+++ b/libraries/protocol/include/steem/protocol/operations.hpp
@@ -62,6 +62,9 @@ namespace steem { namespace protocol {
             reset_account_operation,
             set_reset_account_operation,
             claim_reward_balance_operation,
+#ifdef STEEM_ENABLE_SMT
+            claim_reward_balance2_operation,
+#endif
             delegate_vesting_shares_operation,
             account_create_with_delegation_operation,
             witness_set_properties_operation,

--- a/libraries/protocol/include/steem/protocol/steem_operations.hpp
+++ b/libraries/protocol/include/steem/protocol/steem_operations.hpp
@@ -1010,7 +1010,7 @@ namespace steem { namespace protocol {
       /** \warning Use dedicated add_reward_token method (below) to insert
        *  reward tokens here, or you risk data inconsistency.
        */
-      flat_map< asset_symbol_type, asset > reward_tokens;
+      vector< asset > reward_tokens;
 
       void add_reward_token( const asset& reward_token );
 

--- a/libraries/protocol/include/steem/protocol/steem_operations.hpp
+++ b/libraries/protocol/include/steem/protocol/steem_operations.hpp
@@ -1007,12 +1007,10 @@ namespace steem { namespace protocol {
       account_name_type account;
       extensions_type   extensions;
 
-      /** \warning Use dedicated add_reward_token method (below) to insert
-       *  reward tokens here, or you risk data inconsistency.
+      /** \warning The contents of this container is required to be unique and sorted
+       *  (both by asset symbol) in ascending order. Otherwise operation validation will fail.
        */
       vector< asset > reward_tokens;
-
-      void add_reward_token( const asset& reward_token );
 
       void get_required_posting_authorities( flat_set< account_name_type >& a )const{ a.insert( account ); }
       void validate() const;

--- a/libraries/protocol/include/steem/protocol/steem_operations.hpp
+++ b/libraries/protocol/include/steem/protocol/steem_operations.hpp
@@ -998,6 +998,27 @@ namespace steem { namespace protocol {
       void validate() const;
    };
 
+#ifdef STEEM_ENABLE_SMT
+   /** Differs with original operation with extensions field and a container of tokens that will
+    *  be rewarded to an account. See discussion in issue #1859
+    */
+   struct claim_reward_balance2_operation : public base_operation
+   {
+      account_name_type account;
+      extensions_type   extensions;
+
+      /** \warning Use dedicated add_reward_token method (below) to insert
+       *  reward tokens here, or you risk data inconsistency.
+       */
+      flat_map< asset_symbol_type, asset > reward_tokens;
+
+      void add_reward_token( const asset& reward_token );
+
+      void get_required_posting_authorities( flat_set< account_name_type >& a )const{ a.insert( account ); }
+      void validate() const;
+   };
+#endif
+
    /**
     * Delegate vesting shares from one account to the other. The vesting shares are still owned
     * by the original account, but content voting rights and bandwidth allocation are transferred
@@ -1115,4 +1136,7 @@ FC_REFLECT( steem::protocol::recover_account_operation, (account_to_recover)(new
 FC_REFLECT( steem::protocol::change_recovery_account_operation, (account_to_recover)(new_recovery_account)(extensions) );
 FC_REFLECT( steem::protocol::decline_voting_rights_operation, (account)(decline) );
 FC_REFLECT( steem::protocol::claim_reward_balance_operation, (account)(reward_steem)(reward_sbd)(reward_vests) )
+#ifdef STEEM_ENABLE_SMT
+FC_REFLECT( steem::protocol::claim_reward_balance2_operation, (account)(extensions)(reward_tokens) )
+#endif
 FC_REFLECT( steem::protocol::delegate_vesting_shares_operation, (delegator)(delegatee)(vesting_shares) );

--- a/libraries/protocol/steem_operations.cpp
+++ b/libraries/protocol/steem_operations.cpp
@@ -652,6 +652,8 @@ namespace steem { namespace protocol {
    {
       validate_account_name( account );
       FC_ASSERT( reward_tokens.empty() == false, "Must claim something." );
+      FC_ASSERT( std::is_sorted( reward_tokens.begin(), reward_tokens.end(), nai_less() ), 
+                 "reward_tokens integrity error (most likely a reward token was added not using add_reward_token method)" );
    }
 #endif
 

--- a/libraries/protocol/steem_operations.cpp
+++ b/libraries/protocol/steem_operations.cpp
@@ -653,14 +653,17 @@ namespace steem { namespace protocol {
       validate_account_name( account );
       FC_ASSERT( reward_tokens.empty() == false, "Must claim something." );
       FC_ASSERT( reward_tokens.begin()->amount >= 0, "Cannot claim a negative amount" );
-      for( auto itl = reward_tokens.begin(), itr = ++itl; itr != reward_tokens.end(); ++itl, ++itr )
+      bool is_substantial_reward = reward_tokens.begin()->amount > 0;
+      for( auto itl = reward_tokens.begin(), itr = itl+1; itr != reward_tokens.end(); ++itl, ++itr )
       {
          FC_ASSERT( itl->symbol.to_nai() <= itr->symbol.to_nai(), 
                     "Reward tokens have not been inserted in ascending order." );
          FC_ASSERT( itl->symbol.to_nai() != itr->symbol.to_nai(), 
                     "Duplicate symbol ${s} inserted into claim reward operation container.", ("s", itl->symbol) );
          FC_ASSERT( itr->amount >= 0, "Cannot claim a negative amount" );
+         is_substantial_reward |= itr->amount > 0;
       }
+      FC_ASSERT( is_substantial_reward, "Must claim something." );
    }
 #endif
 

--- a/libraries/protocol/steem_operations.cpp
+++ b/libraries/protocol/steem_operations.cpp
@@ -652,8 +652,15 @@ namespace steem { namespace protocol {
    {
       validate_account_name( account );
       FC_ASSERT( reward_tokens.empty() == false, "Must claim something." );
-      FC_ASSERT( std::is_sorted( reward_tokens.begin(), reward_tokens.end(), nai_less() ), 
-                 "reward_tokens integrity error (most likely a reward token was added not using add_reward_token method)" );
+      FC_ASSERT( reward_tokens.begin()->amount >= 0, "Cannot claim a negative amount" );
+      for( auto itl = reward_tokens.begin(), itr = ++itl; itr != reward_tokens.end(); ++itl, ++itr )
+      {
+         FC_ASSERT( itl->symbol.to_nai() <= itr->symbol.to_nai(), 
+                    "Reward tokens have not been inserted in ascending order." );
+         FC_ASSERT( itl->symbol.to_nai() != itr->symbol.to_nai(), 
+                    "Duplicate symbol ${s} inserted into claim reward operation container.", ("s", itl->symbol) );
+         FC_ASSERT( itr->amount >= 0, "Cannot claim a negative amount" );
+      }
    }
 #endif
 

--- a/libraries/protocol/steem_operations.cpp
+++ b/libraries/protocol/steem_operations.cpp
@@ -642,8 +642,10 @@ namespace steem { namespace protocol {
          return;
       }
 
-      auto insert_info = reward_tokens.insert( std::pair<asset_symbol_type, asset>(reward_token.symbol, reward_token) );
-      FC_ASSERT( insert_info.second, "Duplicate symbol ${s} inserted into claim reward operation container.", ("s", reward_token.symbol) );
+      auto insert_it = lower_bound(reward_tokens.begin(), reward_tokens.end(), reward_token, nai_less());
+      FC_ASSERT( insert_it == reward_tokens.end() || insert_it->symbol.to_nai() != reward_token.symbol.to_nai(),
+                 "Duplicate symbol ${s} inserted into claim reward operation container.", ("s", reward_token.symbol) );
+      reward_tokens.insert( insert_it, reward_token );
    }
 
    void claim_reward_balance2_operation::validate()const

--- a/libraries/protocol/steem_operations.cpp
+++ b/libraries/protocol/steem_operations.cpp
@@ -631,6 +631,28 @@ namespace steem { namespace protocol {
       FC_ASSERT( reward_steem.amount > 0 || reward_sbd.amount > 0 || reward_vests.amount > 0, "Must claim something." );
    }
 
+#ifdef STEEM_ENABLE_SMT
+   void claim_reward_balance2_operation::add_reward_token( const asset& reward_token )
+   {
+      if( reward_token.amount <= 0 )
+      {
+         // Negative amount is invalid.
+         FC_ASSERT( reward_token.amount == 0, "Cannot claim a negative amount" );
+         // Zero amount is ineffective.
+         return;
+      }
+
+      auto insert_info = reward_tokens.insert( std::pair<asset_symbol_type, asset>(reward_token.symbol, reward_token) );
+      FC_ASSERT( insert_info.second, "Duplicate symbol ${s} inserted into claim reward operation container.", ("s", reward_token.symbol) );
+   }
+
+   void claim_reward_balance2_operation::validate()const
+   {
+      validate_account_name( account );
+      FC_ASSERT( reward_tokens.empty() == false, "Must claim something." );
+   }
+#endif
+
    void delegate_vesting_shares_operation::validate()const
    {
       validate_account_name( delegator );

--- a/libraries/protocol/steem_operations.cpp
+++ b/libraries/protocol/steem_operations.cpp
@@ -632,22 +632,6 @@ namespace steem { namespace protocol {
    }
 
 #ifdef STEEM_ENABLE_SMT
-   void claim_reward_balance2_operation::add_reward_token( const asset& reward_token )
-   {
-      if( reward_token.amount <= 0 )
-      {
-         // Negative amount is invalid.
-         FC_ASSERT( reward_token.amount == 0, "Cannot claim a negative amount" );
-         // Zero amount is ineffective.
-         return;
-      }
-
-      auto insert_it = lower_bound(reward_tokens.begin(), reward_tokens.end(), reward_token, nai_less());
-      FC_ASSERT( insert_it == reward_tokens.end() || insert_it->symbol.to_nai() != reward_token.symbol.to_nai(),
-                 "Duplicate symbol ${s} inserted into claim reward operation container.", ("s", reward_token.symbol) );
-      reward_tokens.insert( insert_it, reward_token );
-   }
-
    void claim_reward_balance2_operation::validate()const
    {
       validate_account_name( account );

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -139,6 +139,40 @@ extern uint32_t ( STEEM_TESTING_GENESIS_TIMESTAMP );
 #define ASSET( s ) \
    legacy_asset::from_string( s ).to_asset< false >()
 
+// To be incorporated into fund() method if deemed appropriate.
+// 'SMT' would be dropped from the name then.
+#define FUND_SMT_REWARDS( account_name, amount ) \
+   db->adjust_reward_balance( account_name, amount ); \
+   db->adjust_supply( amount ); \
+   generate_block();
+
+#define OP2TX(OP,TX,KEY) \
+TX.operations.push_back( OP ); \
+TX.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION ); \
+TX.sign( KEY, db->get_chain_id() );
+
+#define PUSH_OP(OP,KEY) \
+{ \
+   signed_transaction tx; \
+   OP2TX(OP,tx,KEY) \
+   db->push_transaction( tx, 0 ); \
+}
+
+#define PUSH_OP_TWICE(OP,KEY) \
+{ \
+   signed_transaction tx; \
+   OP2TX(OP,tx,KEY) \
+   db->push_transaction( tx, 0 ); \
+   db->push_transaction( tx, database::skip_transaction_dupe_check ); \
+}
+
+#define FAIL_WITH_OP(OP,KEY,EXCEPTION) \
+{ \
+   signed_transaction tx; \
+   OP2TX(OP,tx,KEY) \
+   STEEM_REQUIRE_THROW( db->push_transaction( tx, 0 ), EXCEPTION ); \
+}
+
 namespace steem { namespace chain {
 
 using namespace steem::protocol;

--- a/tests/tests/smt_operation_tests.cpp
+++ b/tests/tests/smt_operation_tests.cpp
@@ -984,6 +984,22 @@ BOOST_AUTO_TEST_CASE( claim_reward_balance2_validate )
       STEEM_REQUIRE_THROW( op.add_reward_token( asset( -1, smt1 ) ), fc::assert_exception );
       STEEM_REQUIRE_THROW( op.add_reward_token( asset( -1, smt2 ) ), fc::assert_exception );
       STEEM_REQUIRE_THROW( op.add_reward_token( asset( -1, smt3 ) ), fc::assert_exception );
+      
+      BOOST_TEST_MESSAGE( "Testing inconsistencies of manually inserted reward tokens." );
+      op.reward_tokens.push_back( asset( 1, smt3 ) );
+      op.reward_tokens.push_back( asset( 1, smt1 ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( asset( 1, smt3 ) );
+      op.reward_tokens.push_back( asset( 1, smt3 ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( asset( -1, smt3 ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( asset( 1, smt1 ) );
+      op.reward_tokens.push_back( asset( -1, smt3 ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
    }
    FC_LOG_AND_RETHROW()
 }

--- a/tests/tests/smt_operation_tests.cpp
+++ b/tests/tests/smt_operation_tests.cpp
@@ -945,16 +945,8 @@ BOOST_AUTO_TEST_CASE( claim_reward_balance2_validate )
       STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
 
       BOOST_TEST_MESSAGE( "Testing ineffective rewards" );
-      // Using add_reward_token.
-      op.add_reward_token( ASSET( "0.000 TESTS" ) );
-      op.add_reward_token( ASSET( "0.000 TBD" ) );
-      op.add_reward_token( ASSET( "0.000000 VESTS" ) );
-      op.add_reward_token( asset( 0, smt1 ) );
-      op.add_reward_token( asset( 0, smt2 ) );
-      op.add_reward_token( asset( 0, smt3 ) );
       STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
       // Manually inserted.
-      op.reward_tokens.clear();
       op.reward_tokens.push_back( ASSET( "0.000 TESTS" ) );
       STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
       op.reward_tokens.clear();
@@ -972,59 +964,34 @@ BOOST_AUTO_TEST_CASE( claim_reward_balance2_validate )
       op.reward_tokens.clear();
       op.reward_tokens.push_back( asset( 0, smt3 ) );
       STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
 
       BOOST_TEST_MESSAGE( "Testing single reward claims" );
-      op.add_reward_token( ASSET( "1.000 TESTS" ) );
-      op.validate();
-      op.reward_tokens.clear();
       op.reward_tokens.push_back( ASSET( "1.000 TESTS" ) );
       op.validate();
       op.reward_tokens.clear();
 
-      op.add_reward_token( ASSET( "1.000 TBD" ) );
-      op.validate();
-      op.reward_tokens.clear();
       op.reward_tokens.push_back( ASSET( "1.000 TBD" ) );
       op.validate();
       op.reward_tokens.clear();
 
-      op.add_reward_token( ASSET( "1.000000 VESTS" ) );
-      op.validate();
-      op.reward_tokens.clear();
       op.reward_tokens.push_back( ASSET( "1.000000 VESTS" ) );
       op.validate();
       op.reward_tokens.clear();
 
-      op.add_reward_token( asset( 1, smt1 ) );
-      op.validate();
-      op.reward_tokens.clear();
       op.reward_tokens.push_back( asset( 1, smt1 ) );
       op.validate();
       op.reward_tokens.clear();
 
-      op.add_reward_token( asset( 1, smt2 ) );
-      op.validate();
-      op.reward_tokens.clear();
       op.reward_tokens.push_back( asset( 1, smt2 ) );
       op.validate();
       op.reward_tokens.clear();
 
-      op.add_reward_token( asset( 1, smt3 ) );
-      op.validate();
-      op.reward_tokens.clear();
       op.reward_tokens.push_back( asset( 1, smt3 ) );
       op.validate();
       op.reward_tokens.clear();
 
       BOOST_TEST_MESSAGE( "Testing multiple rewards" );
-      op.add_reward_token( ASSET( "1.000 TESTS" ) );
-      op.add_reward_token( ASSET( "1.000 TBD" ) );
-      op.add_reward_token( ASSET( "1.000000 VESTS" ) );
-      op.add_reward_token( asset( 1, smt1 ) );
-      op.add_reward_token( asset( 1, smt2 ) );
-      op.add_reward_token( asset( 1, smt3 ) );
-      op.validate();
-      op.reward_tokens.clear();
       op.reward_tokens.push_back( ASSET( "1.000 TBD" ) );
       op.reward_tokens.push_back( ASSET( "1.000 TESTS" ) );
       op.reward_tokens.push_back( ASSET( "1.000000 VESTS" ) );
@@ -1035,12 +1002,6 @@ BOOST_AUTO_TEST_CASE( claim_reward_balance2_validate )
       op.reward_tokens.clear();
 
       BOOST_TEST_MESSAGE( "Testing invalid rewards" );
-      STEEM_REQUIRE_THROW( op.add_reward_token( ASSET( "-1.000 TESTS" ) ), fc::assert_exception );
-      STEEM_REQUIRE_THROW( op.add_reward_token( ASSET( "-1.000 TBD" ) ), fc::assert_exception );
-      STEEM_REQUIRE_THROW( op.add_reward_token( ASSET( "-1.000000 VESTS" ) ), fc::assert_exception );
-      STEEM_REQUIRE_THROW( op.add_reward_token( asset( -1, smt1 ) ), fc::assert_exception );
-      STEEM_REQUIRE_THROW( op.add_reward_token( asset( -1, smt2 ) ), fc::assert_exception );
-      STEEM_REQUIRE_THROW( op.add_reward_token( asset( -1, smt3 ) ), fc::assert_exception );
       op.reward_tokens.push_back( ASSET( "-1.000 TESTS" ) );
       STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
       op.reward_tokens.clear();
@@ -1061,9 +1022,6 @@ BOOST_AUTO_TEST_CASE( claim_reward_balance2_validate )
       op.reward_tokens.clear();
       
       BOOST_TEST_MESSAGE( "Testing duplicated reward tokens." );
-      op.add_reward_token( ASSET( "1.000 TESTS" ) );
-      STEEM_REQUIRE_THROW( op.add_reward_token( ASSET( "2.000 TESTS" ) ), fc::assert_exception );
-      op.reward_tokens.clear();
       op.reward_tokens.push_back( asset( 1, smt3 ) );
       op.reward_tokens.push_back( asset( 1, smt3 ) );
       STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );

--- a/tests/tests/smt_operation_tests.cpp
+++ b/tests/tests/smt_operation_tests.cpp
@@ -945,35 +945,92 @@ BOOST_AUTO_TEST_CASE( claim_reward_balance2_validate )
       STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
 
       BOOST_TEST_MESSAGE( "Testing ineffective rewards" );
+      // Using add_reward_token.
       op.add_reward_token( ASSET( "0.000 TESTS" ) );
       op.add_reward_token( ASSET( "0.000 TBD" ) );
       op.add_reward_token( ASSET( "0.000000 VESTS" ) );
       op.add_reward_token( asset( 0, smt1 ) );
       op.add_reward_token( asset( 0, smt2 ) );
       op.add_reward_token( asset( 0, smt3 ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      // Manually inserted.
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( ASSET( "0.000 TESTS" ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( ASSET( "0.000 TBD" ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( ASSET( "0.000000 VESTS" ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( asset( 0, smt1 ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( asset( 0, smt2 ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( asset( 0, smt3 ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
 
       BOOST_TEST_MESSAGE( "Testing single reward claims" );
       op.add_reward_token( ASSET( "1.000 TESTS" ) );
+      op.validate();
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( ASSET( "1.000 TESTS" ) );
       op.validate();
       op.reward_tokens.clear();
 
       op.add_reward_token( ASSET( "1.000 TBD" ) );
       op.validate();
       op.reward_tokens.clear();
+      op.reward_tokens.push_back( ASSET( "1.000 TBD" ) );
+      op.validate();
+      op.reward_tokens.clear();
 
       op.add_reward_token( ASSET( "1.000000 VESTS" ) );
+      op.validate();
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( ASSET( "1.000000 VESTS" ) );
       op.validate();
       op.reward_tokens.clear();
 
       op.add_reward_token( asset( 1, smt1 ) );
       op.validate();
       op.reward_tokens.clear();
+      op.reward_tokens.push_back( asset( 1, smt1 ) );
+      op.validate();
+      op.reward_tokens.clear();
 
       op.add_reward_token( asset( 1, smt2 ) );
       op.validate();
       op.reward_tokens.clear();
+      op.reward_tokens.push_back( asset( 1, smt2 ) );
+      op.validate();
+      op.reward_tokens.clear();
 
       op.add_reward_token( asset( 1, smt3 ) );
+      op.validate();
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( asset( 1, smt3 ) );
+      op.validate();
+      op.reward_tokens.clear();
+
+      BOOST_TEST_MESSAGE( "Testing multiple rewards" );
+      op.add_reward_token( ASSET( "1.000 TESTS" ) );
+      op.add_reward_token( ASSET( "1.000 TBD" ) );
+      op.add_reward_token( ASSET( "1.000000 VESTS" ) );
+      op.add_reward_token( asset( 1, smt1 ) );
+      op.add_reward_token( asset( 1, smt2 ) );
+      op.add_reward_token( asset( 1, smt3 ) );
+      op.validate();
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( ASSET( "1.000 TBD" ) );
+      op.reward_tokens.push_back( ASSET( "1.000 TESTS" ) );
+      op.reward_tokens.push_back( ASSET( "1.000000 VESTS" ) );
+      op.reward_tokens.push_back( asset( 1, smt1 ) );
+      op.reward_tokens.push_back( asset( 1, smt3 ) );
+      op.reward_tokens.push_back( asset( 1, smt2 ) );
       op.validate();
       op.reward_tokens.clear();
 
@@ -984,17 +1041,40 @@ BOOST_AUTO_TEST_CASE( claim_reward_balance2_validate )
       STEEM_REQUIRE_THROW( op.add_reward_token( asset( -1, smt1 ) ), fc::assert_exception );
       STEEM_REQUIRE_THROW( op.add_reward_token( asset( -1, smt2 ) ), fc::assert_exception );
       STEEM_REQUIRE_THROW( op.add_reward_token( asset( -1, smt3 ) ), fc::assert_exception );
-      
-      BOOST_TEST_MESSAGE( "Testing inconsistencies of manually inserted reward tokens." );
-      op.reward_tokens.push_back( asset( 1, smt3 ) );
-      op.reward_tokens.push_back( asset( 1, smt1 ) );
+      op.reward_tokens.push_back( ASSET( "-1.000 TESTS" ) );
       STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
       op.reward_tokens.clear();
-      op.reward_tokens.push_back( asset( 1, smt3 ) );
-      op.reward_tokens.push_back( asset( 1, smt3 ) );
+      op.reward_tokens.push_back( ASSET( "-1.000 TBD" ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( ASSET( "-1.000 VESTS" ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( asset( -1, smt1 ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( asset( -1, smt2 ) );
       STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
       op.reward_tokens.clear();
       op.reward_tokens.push_back( asset( -1, smt3 ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+      
+      BOOST_TEST_MESSAGE( "Testing duplicated reward tokens." );
+      op.add_reward_token( ASSET( "1.000 TESTS" ) );
+      STEEM_REQUIRE_THROW( op.add_reward_token( ASSET( "2.000 TESTS" ) ), fc::assert_exception );
+      op.reward_tokens.clear();
+      op.reward_tokens.push_back( asset( 1, smt3 ) );
+      op.reward_tokens.push_back( asset( 1, smt3 ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.clear();
+
+      BOOST_TEST_MESSAGE( "Testing inconsistencies of manually inserted reward tokens." );
+      op.reward_tokens.push_back( ASSET( "1.000 TESTS" ) );
+      op.reward_tokens.push_back( ASSET( "1.000 TBD" ) );
+      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      op.reward_tokens.push_back( asset( 1, smt3 ) );
+      op.reward_tokens.push_back( asset( 1, smt1 ) );
       STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
       op.reward_tokens.clear();
       op.reward_tokens.push_back( asset( 1, smt1 ) );

--- a/tests/tests/smt_operation_tests.cpp
+++ b/tests/tests/smt_operation_tests.cpp
@@ -1067,5 +1067,133 @@ BOOST_AUTO_TEST_CASE( claim_reward_balance2_authorities )
    FC_LOG_AND_RETHROW()
 }
 
+BOOST_AUTO_TEST_CASE( claim_reward_balance2_apply )
+{
+   try
+   {
+      BOOST_TEST_MESSAGE( "Testing: claim_reward_balance2_apply" );
+      BOOST_TEST_MESSAGE( "--- Setting up test state" );
+
+      ACTORS( (alice) )
+      generate_block();
+
+      auto smts = create_smt_3( "alice", alice_private_key );
+      const auto& smt1 = smts[0];
+      const auto& smt2 = smts[1];
+      const auto& smt3 = smts[2];
+
+      FUND_SMT_REWARDS( "alice", asset( 10*std::pow(10, smt1.decimals()), smt1 ) );
+      FUND_SMT_REWARDS( "alice", asset( 10*std::pow(10, smt2.decimals()), smt2 ) );
+      FUND_SMT_REWARDS( "alice", asset( 10*std::pow(10, smt3.decimals()), smt3 ) );
+
+      db_plugin->debug_update( []( database& db )
+      {
+         db.modify( db.get_account( "alice" ), []( account_object& a )
+         {
+            a.reward_sbd_balance = ASSET( "10.000 TBD" );
+            a.reward_steem_balance = ASSET( "10.000 TESTS" );
+            a.reward_vesting_balance = ASSET( "10.000000 VESTS" );
+            a.reward_vesting_steem = ASSET( "10.000 TESTS" );
+         });
+
+         db.modify( db.get_dynamic_global_properties(), []( dynamic_global_property_object& gpo )
+         {
+            gpo.current_sbd_supply += ASSET( "10.000 TBD" );
+            gpo.current_supply += ASSET( "20.000 TESTS" );
+            gpo.virtual_supply += ASSET( "20.000 TESTS" );
+            gpo.pending_rewarded_vesting_shares += ASSET( "10.000000 VESTS" );
+            gpo.pending_rewarded_vesting_steem += ASSET( "10.000 TESTS" );
+         });
+      });
+
+      generate_block();
+      validate_database();
+
+      auto alice_steem = db->get_account( "alice" ).balance;
+      auto alice_sbd = db->get_account( "alice" ).sbd_balance;
+      auto alice_vests = db->get_account( "alice" ).vesting_shares;
+      auto alice_smt1 = db->get_balance( "alice", smt1 );
+      auto alice_smt2 = db->get_balance( "alice", smt2 );
+      auto alice_smt3 = db->get_balance( "alice", smt3 );
+
+      claim_reward_balance2_operation op;
+      op.account = "alice";
+
+      BOOST_TEST_MESSAGE( "--- Attempting to claim more than exists in the reward balance." );
+      // Legacy symbols
+      op.reward_tokens.push_back( ASSET( "0.000 TBD" ) );
+      op.reward_tokens.push_back( ASSET( "20.000 TESTS" ) );
+      op.reward_tokens.push_back( ASSET( "0.000000 VESTS" ) );
+      FAIL_WITH_OP(op, alice_private_key, fc::assert_exception);
+      op.reward_tokens.clear();
+      // SMTs
+      op.reward_tokens.push_back( asset( 0, smt1 ) );
+      op.reward_tokens.push_back( asset( 20*std::pow(10, smt3.decimals()), smt3 ) );
+      op.reward_tokens.push_back( asset( 0, smt2 ) );
+      FAIL_WITH_OP(op, alice_private_key, fc::assert_exception);
+      op.reward_tokens.clear();
+
+      BOOST_TEST_MESSAGE( "--- Claiming a partial reward balance" );
+      // Legacy symbols
+      asset partial_vests = ASSET( "5.000000 VESTS" );
+      op.reward_tokens.push_back( ASSET( "0.000 TBD" ) );
+      op.reward_tokens.push_back( ASSET( "0.000 TESTS" ) );
+      op.reward_tokens.push_back( partial_vests );
+      PUSH_OP(op, alice_private_key);
+      BOOST_REQUIRE( db->get_account( "alice" ).balance == alice_steem + ASSET( "0.000 TESTS" ) );
+      BOOST_REQUIRE( db->get_account( "alice" ).reward_steem_balance == ASSET( "10.000 TESTS" ) );
+      BOOST_REQUIRE( db->get_account( "alice" ).sbd_balance == alice_sbd + ASSET( "0.000 TBD" ) );
+      BOOST_REQUIRE( db->get_account( "alice" ).reward_sbd_balance == ASSET( "10.000 TBD" ) );
+      BOOST_REQUIRE( db->get_account( "alice" ).vesting_shares == alice_vests + partial_vests );
+      BOOST_REQUIRE( db->get_account( "alice" ).reward_vesting_balance == ASSET( "5.000000 VESTS" ) );
+      BOOST_REQUIRE( db->get_account( "alice" ).reward_vesting_steem == ASSET( "5.000 TESTS" ) );
+      validate_database();
+      alice_vests += partial_vests;
+      op.reward_tokens.clear();
+      // SMTs
+      asset partial_smt2 = asset( 5*std::pow(10, smt2.decimals()), smt2 );
+      op.reward_tokens.push_back( asset( 0, smt1 ) );
+      op.reward_tokens.push_back( asset( 0, smt3 ) );
+      op.reward_tokens.push_back( partial_smt2 );
+      PUSH_OP(op, alice_private_key);
+      BOOST_REQUIRE( db->get_balance( "alice", smt1 ) == alice_smt1 + asset( 0, smt1 ) );
+      BOOST_REQUIRE( db->get_balance( "alice", smt3 ) == alice_smt3 + asset( 0, smt3 ) );
+      BOOST_REQUIRE( db->get_balance( "alice", smt2 ) == alice_smt2 + partial_smt2 );
+      validate_database();
+      alice_smt2 += partial_smt2;
+      op.reward_tokens.clear();
+
+      BOOST_TEST_MESSAGE( "--- Claiming the full reward balance" );
+      // Legacy symbols
+      asset full_steem = ASSET( "10.000 TESTS" );
+      asset full_sbd = ASSET( "10.000 TBD" );
+      op.reward_tokens.push_back( full_sbd );
+      op.reward_tokens.push_back( full_steem );
+      op.reward_tokens.push_back( partial_vests );
+      PUSH_OP(op, alice_private_key);
+      BOOST_REQUIRE( db->get_account( "alice" ).balance == alice_steem + full_steem );
+      BOOST_REQUIRE( db->get_account( "alice" ).reward_steem_balance == ASSET( "0.000 TESTS" ) );
+      BOOST_REQUIRE( db->get_account( "alice" ).sbd_balance == alice_sbd + full_sbd );
+      BOOST_REQUIRE( db->get_account( "alice" ).reward_sbd_balance == ASSET( "0.000 TBD" ) );
+      BOOST_REQUIRE( db->get_account( "alice" ).vesting_shares == alice_vests + partial_vests );
+      BOOST_REQUIRE( db->get_account( "alice" ).reward_vesting_balance == ASSET( "0.000000 VESTS" ) );
+      BOOST_REQUIRE( db->get_account( "alice" ).reward_vesting_steem == ASSET( "0.000 TESTS" ) );
+      validate_database();
+      op.reward_tokens.clear();
+      // SMTs
+      asset full_smt1 = asset( 10*std::pow(10, smt1.decimals()), smt1 );
+      asset full_smt3 = asset( 10*std::pow(10, smt3.decimals()), smt3 );
+      op.reward_tokens.push_back( full_smt1 );
+      op.reward_tokens.push_back( full_smt3 );
+      op.reward_tokens.push_back( partial_smt2 );
+      PUSH_OP(op, alice_private_key);
+      BOOST_REQUIRE( db->get_balance( "alice", smt1 ) == alice_smt1 + full_smt1 );
+      BOOST_REQUIRE( db->get_balance( "alice", smt3 ) == alice_smt3 + full_smt3 );
+      BOOST_REQUIRE( db->get_balance( "alice", smt2 ) == alice_smt2 + partial_smt2 );
+      validate_database();
+   }
+   FC_LOG_AND_RETHROW()
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 #endif

--- a/tests/tests/smt_tests.cpp
+++ b/tests/tests/smt_tests.cpp
@@ -105,33 +105,6 @@ BOOST_AUTO_TEST_CASE( smt_create_authorities )
    FC_LOG_AND_RETHROW()
 }
 
-#define OP2TX(OP,TX,KEY) \
-TX.operations.push_back( OP ); \
-TX.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION ); \
-TX.sign( KEY, db->get_chain_id() );
-
-#define PUSH_OP(OP,KEY) \
-{ \
-   signed_transaction tx; \
-   OP2TX(OP,tx,KEY) \
-   db->push_transaction( tx, 0 ); \
-}
-
-#define PUSH_OP_TWICE(OP,KEY) \
-{ \
-   signed_transaction tx; \
-   OP2TX(OP,tx,KEY) \
-   db->push_transaction( tx, 0 ); \
-   db->push_transaction( tx, database::skip_transaction_dupe_check ); \
-}
-
-#define FAIL_WITH_OP(OP,KEY,EXCEPTION) \
-{ \
-   signed_transaction tx; \
-   OP2TX(OP,tx,KEY) \
-   STEEM_REQUIRE_THROW( db->push_transaction( tx, 0 ), EXCEPTION ); \
-}
-
 BOOST_AUTO_TEST_CASE( smt_create_apply )
 {
    try


### PR DESCRIPTION
As requested `reward_tokens` container was changed to `vector` and a separate comparator was added to `asset.hpp` #1896 #2067