### PR TITLE
Updated temporary NAI generation to latest spec

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -4556,8 +4556,6 @@ void database::retally_witness_vote_counts( bool force )
 // 5. The least significant bit is used as liquid/vesting variant indicator so the 10 and 90 milions are numbers
 //    of liquid/vesting *pairs* of reserved/available NAIs.
 // 6. 45 milions of SMT await for their creators.
-#define LOWEST_AVAILABLE_NAI 10000000
-#define HIGHEST_AVAILABLE_NAI 99999999
 
 vector< asset_symbol_type > database::get_smt_next_identifier()
 {
@@ -4569,8 +4567,8 @@ vector< asset_symbol_type > database::get_smt_next_identifier()
 
    uint8_t decimal_places = 0;
 
-   FC_ASSERT( _next_available_nai >= LOWEST_AVAILABLE_NAI );
-   FC_ASSERT( _next_available_nai <= HIGHEST_AVAILABLE_NAI, "Out of available NAI numbers." );
+   FC_ASSERT( _next_available_nai >= SMT_MIN_NON_RESERVED_NAI );
+   FC_ASSERT( _next_available_nai <= SMT_MAX_NAI, "Out of available NAI numbers." );
    // Assume that _next_available_nai value shows the liquid version of NAI.
    FC_ASSERT( (_next_available_nai & 0x1) == 0, "Can't start with vesting version of NAI." );
    uint32_t new_nai = _next_available_nai;

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -4547,6 +4547,18 @@ void database::retally_witness_vote_counts( bool force )
 }
 
 #ifdef STEEM_ENABLE_SMT
+// 1. NAI number is stored in 32 bits, minus 4 for precision, minus 1 for control.
+// 2. NAI string has 8 characters (each between '0' and '9') available (11 minus '@@', minus checksum character is 8 )
+// 3. Max 27 bit decimal is 134,217,727 but only 8 characters are available to represent it as string so we are left
+//    with [0 : 99,999,999] range.
+// 4. The numbers starting with 0 decimal digit are reserved. Now we are left with 10 milions of reserved NAIs
+//    [0 : 09,999,999] and 90 millions available for SMT creators [10,000,000 : 99,999,999]
+// 5. The least significant bit is used as liquid/vesting variant indicator so the 10 and 90 milions are numbers
+//    of liquid/vesting *pairs* of reserved/available NAIs.
+// 6. 45 milions of SMT await for their creators.
+#define LOWEST_AVAILABLE_NAI 10000000
+#define HIGHEST_AVAILABLE_NAI 99999999
+
 vector< asset_symbol_type > database::get_smt_next_identifier()
 {
    // This is temporary dummy implementation using simple counter as nai source (_next_available_nai).
@@ -4556,12 +4568,17 @@ vector< asset_symbol_type > database::get_smt_next_identifier()
    // For appropriate use of this method see e.g. smt_database_fixture::create_smt
 
    uint8_t decimal_places = 0;
-   FC_ASSERT( _next_available_nai >= SMT_MIN_NAI );
-   FC_ASSERT( _next_available_nai <= SMT_MAX_NAI, "Out of available NAI numbers." );
 
-   uint32_t asset_num = (_next_available_nai++ << 5) | 0x10 | decimal_places;
+   FC_ASSERT( _next_available_nai >= LOWEST_AVAILABLE_NAI );
+   FC_ASSERT( _next_available_nai <= HIGHEST_AVAILABLE_NAI, "Out of available NAI numbers." );
+   // Assume that _next_available_nai value shows the liquid version of NAI.
+   FC_ASSERT( (_next_available_nai & 0x1) == 0, "Can't start with vesting version of NAI." );
+   uint32_t new_nai = _next_available_nai;
+   // Skip vesting version of produced NAI - it differs only by least significant bit set.
+   _next_available_nai += 2;
 
-   asset_symbol_type new_symbol = asset_symbol_type::from_asset_num( asset_num );
+   uint32_t new_asset_num = (new_nai << 5) | 0x10 | decimal_places;
+   asset_symbol_type new_symbol = asset_symbol_type::from_asset_num( new_asset_num );
    new_symbol.validate();
    FC_ASSERT( new_symbol.space() == asset_symbol_type::smt_nai_space );
 

--- a/libraries/chain/include/steem/chain/database.hpp
+++ b/libraries/chain/include/steem/chain/database.hpp
@@ -525,7 +525,8 @@ namespace steem { namespace chain {
          uint32_t                      _next_flush_block = 0;
 
          uint32_t                      _last_free_gb_printed = 0;
-         uint32_t                      _next_available_nai = 4;
+         /// For Initial value see appropriate comment where get_smt_next_identifier is implemented.
+         uint32_t                      _next_available_nai = 10000000;
 
          flat_map< std::string, std::shared_ptr< custom_operation_interpreter > >   _custom_operation_interpreters;
          std::string                   _json_schema;

--- a/libraries/chain/include/steem/chain/database.hpp
+++ b/libraries/chain/include/steem/chain/database.hpp
@@ -526,7 +526,7 @@ namespace steem { namespace chain {
 
          uint32_t                      _last_free_gb_printed = 0;
          /// For Initial value see appropriate comment where get_smt_next_identifier is implemented.
-         uint32_t                      _next_available_nai = 10000000;
+         uint32_t                      _next_available_nai = SMT_MIN_NON_RESERVED_NAI;
 
          flat_map< std::string, std::shared_ptr< custom_operation_interpreter > >   _custom_operation_interpreters;
          std::string                   _json_schema;

--- a/libraries/protocol/include/steem/protocol/asset_symbol.hpp
+++ b/libraries/protocol/include/steem/protocol/asset_symbol.hpp
@@ -6,6 +6,7 @@
 #define STEEM_ASSET_SYMBOL_PRECISION_BITS    4
 #define SMT_MAX_NAI                          99999999
 #define SMT_MIN_NAI                          1
+#define SMT_MIN_NON_RESERVED_NAI             10000000
 #define STEEM_ASSET_SYMBOL_NAI_LENGTH        10
 #define STEEM_ASSET_SYMBOL_NAI_STRING_LENGTH ( STEEM_ASSET_SYMBOL_NAI_LENGTH + 2 )
 


### PR DESCRIPTION
Implemented vesting bit and reservation of NAIs beginning with `0` #2063