### PR TITLE
 Modified smt_token_object to represent both liquid and vesting variant of SMT

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -4411,9 +4411,10 @@ void database::validate_smt_invariants()const
       for( ; itr != end; ++itr )
       {
          const smt_token_object& smt = *itr;
-         auto totalIt = theMap.find( smt.symbol );
-         asset total_supply = totalIt == theMap.end() ? asset(0, smt.symbol) : totalIt->second;
-         FC_ASSERT( asset(smt.current_supply, smt.symbol) == total_supply, "", ("smt current_supply",smt.current_supply)("total_supply",total_supply) );
+         auto totalIt = theMap.find( smt.liquid_symbol );
+         asset total_liquid_supply = totalIt == theMap.end() ? asset(0, smt.liquid_symbol) : totalIt->second;
+         FC_ASSERT( asset(smt.current_supply, smt.liquid_symbol) == total_liquid_supply,
+                    "", ("smt current_supply",smt.current_supply)("total_liquid_supply",total_liquid_supply) );
       }
    }
    FC_CAPTURE_LOG_AND_RETHROW( (head_block_num()) );

--- a/libraries/chain/smt_evaluator.cpp
+++ b/libraries/chain/smt_evaluator.cpp
@@ -108,11 +108,12 @@ void smt_create_evaluator::do_apply( const smt_create_operation& o )
    _db.adjust_balance( o.control_account , -o.smt_creation_fee );
    _db.adjust_balance( STEEM_NULL_ACCOUNT,  o.smt_creation_fee );
 
+   // Create SMT object common to both liquid and vesting variants of SMT.
    _db.create< smt_token_object >( [&]( smt_token_object& token )
    {
-      token.symbol = o.symbol;
+      token.liquid_symbol = o.symbol;
       token.control_account = o.control_account;
-      token.market_maker.token_balance = asset( 0, token.symbol );
+      token.market_maker.token_balance = asset( 0, token.liquid_symbol );
    });
 }
 
@@ -140,7 +141,7 @@ void smt_setup_emissions_evaluator::do_apply( const smt_setup_emissions_operatio
 
    const smt_token_object& smt = common_pre_setup_evaluation(_db, o.symbol, o.control_account);
 
-   FC_ASSERT( o.lep_abs_amount.symbol == smt.symbol );
+   FC_ASSERT( o.lep_abs_amount.symbol == smt.liquid_symbol );
    // ^ Note that rep_abs_amount.symbol has been matched to lep's in validate().
 
    _db.modify( smt, [&]( smt_token_object& token )

--- a/libraries/protocol/smt_operations.cpp
+++ b/libraries/protocol/smt_operations.cpp
@@ -12,8 +12,9 @@ void smt_create_operation::validate()const
    FC_ASSERT( smt_creation_fee.amount >= 0, "fee cannot be negative" );
    FC_ASSERT( smt_creation_fee.amount <= STEEM_MAX_SHARE_SUPPLY, "Fee must be smaller than STEEM_MAX_SHARE_SUPPLY" );
    FC_ASSERT( is_asset_type( smt_creation_fee, STEEM_SYMBOL ) || is_asset_type( smt_creation_fee, SBD_SYMBOL ), "Fee must be STEEM or SBD" );
-   FC_ASSERT( symbol.space() == asset_symbol_type::smt_nai_space, "legacy symbol used instead of NAI" );
    symbol.validate();
+   FC_ASSERT( symbol.space() == asset_symbol_type::smt_nai_space, "legacy symbol used instead of NAI" );
+   FC_ASSERT( symbol.is_vesting() == false, "liquid variant of NAI expected");
    FC_ASSERT( symbol.decimals() == precision, "Mismatch between redundantly provided precision ${prec1} vs ${prec2}",
       ("prec1",symbol.decimals())("prec2",precision) );
 }
@@ -188,6 +189,8 @@ void smt_setup_emissions_operation::validate()const
    FC_ASSERT( schedule_time <= lep_time || lep_time == rep_time );
    // ^ lep_time is either later or non-important
 
+   FC_ASSERT( (lep_abs_amount.symbol.is_vesting() == false),
+              "Use liquid variant of SMT symbol to specify emission amounts" );
    FC_ASSERT( lep_abs_amount.symbol == rep_abs_amount.symbol );
    FC_ASSERT( lep_abs_amount.amount >= 0 && rep_abs_amount.amount >= 0 );
    FC_ASSERT( lep_abs_amount.amount != rep_abs_amount.amount || lep_abs_amount.amount > 0 );

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -227,6 +227,16 @@ asset_symbol_type database_fixture::name_to_asset_symbol( const std::string& nam
    return asset_symbol_type::from_asset_num( asset_num );
 }
 
+asset_symbol_type database_fixture::get_new_smt_symbol( uint8_t token_decimal_places, chain::database* db )
+{
+   // The list of available nais is not dependent on SMT desired precision (token_decimal_places).
+   auto available_nais =  db->get_smt_next_identifier();
+   FC_ASSERT( available_nais.size() > 0, "No available nai returned by get_smt_next_identifier." );
+   const asset_symbol_type& new_nai = available_nais[0];
+   // Note that token's precision is needed now, when creating actual symbol.
+   return asset_symbol_type::from_nai( new_nai.to_nai(), token_decimal_places );
+}
+
 string database_fixture::generate_anon_acct_name()
 {
    // names of the form "anon-acct-x123" ; the "x" is necessary
@@ -599,7 +609,6 @@ void database_fixture::validate_database( void )
 
 template< typename T >
 asset_symbol_type t_smt_database_fixture< T >::create_smt( const string& account_name, const fc::ecc::private_key& key,
-
    uint8_t token_decimal_places )
 {
    smt_create_operation op;
@@ -612,12 +621,7 @@ asset_symbol_type t_smt_database_fixture< T >::create_smt( const string& account
       set_price_feed( price( ASSET( "1.000 TBD" ), ASSET( "1.000 TESTS" ) ) );
       convert( account_name, ASSET( "5000.000 TESTS" ) );
 
-      // The list of available nais is not dependent on SMT desired precision (token_decimal_places).
-      auto available_nais =  this->db->get_smt_next_identifier();
-      FC_ASSERT( available_nais.size() > 0, "No available nai returned by get_smt_next_identifier." );
-      const asset_symbol_type& new_nai = available_nais[0];
-      // Note that token's precision is needed now, when creating actual symbol.
-      op.symbol = asset_symbol_type::from_nai( new_nai.to_nai(), token_decimal_places );
+      op.symbol = this->get_new_smt_symbol( token_decimal_places, this->db );
       op.precision = op.symbol.decimals();
       op.smt_creation_fee = ASSET( "1000.000 TBD" );
       op.control_account = account_name;
@@ -642,9 +646,9 @@ void sub_set_create_op(smt_create_operation* op, account_name_type control_acoun
    op->control_account = control_acount;
 }
 
-void set_create_op(smt_create_operation* op, account_name_type control_account, std::string token_name, uint8_t token_decimal_places)
+void set_create_op(chain::database* db, smt_create_operation* op, account_name_type control_account, uint8_t token_decimal_places)
 {
-   op->symbol = database_fixture::name_to_asset_symbol(token_name, token_decimal_places);
+   op->symbol = database_fixture::get_new_smt_symbol( token_decimal_places, db );
    sub_set_create_op(op, control_account);
 }
 
@@ -660,8 +664,6 @@ std::array<asset_symbol_type, 3> t_smt_database_fixture< T >::create_smt_3(const
    smt_create_operation op0;
    smt_create_operation op1;
    smt_create_operation op2;
-   std::string token_name(control_account_name);
-   token_name.resize(2);
 
    try
    {
@@ -671,9 +673,9 @@ std::array<asset_symbol_type, 3> t_smt_database_fixture< T >::create_smt_3(const
       set_price_feed( price( ASSET( "1.000 TBD" ), ASSET( "1.000 TESTS" ) ) );
       convert( control_account_name, ASSET( "5000.000 TESTS" ) );
 
-      set_create_op(&op0, control_account_name, token_name + "0", 0);
-      set_create_op(&op1, control_account_name, token_name + "1", 1);
-      set_create_op(&op2, control_account_name, token_name + "2", 1);
+      set_create_op(this->db, &op0, control_account_name, 0);
+      set_create_op(this->db, &op1, control_account_name, 1);
+      set_create_op(this->db, &op2, control_account_name, 1);
 
       signed_transaction tx;
       tx.operations.push_back( op0 );
@@ -708,7 +710,7 @@ void t_smt_database_fixture< T >::create_invalid_smt( const char* control_accoun
 {
    // Fail due to precision too big.
    smt_create_operation op_precision;
-   STEEM_REQUIRE_THROW( set_create_op(&op_precision, control_account_name, "smt", STEEM_ASSET_MAX_DECIMALS + 1), fc::assert_exception );
+   STEEM_REQUIRE_THROW( set_create_op(this->db, &op_precision, control_account_name, STEEM_ASSET_MAX_DECIMALS + 1), fc::assert_exception );
 }
 
 template< typename T >

--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -227,6 +227,7 @@ asset_symbol_type database_fixture::name_to_asset_symbol( const std::string& nam
    return asset_symbol_type::from_asset_num( asset_num );
 }
 
+#ifdef STEEM_ENABLE_SMT
 asset_symbol_type database_fixture::get_new_smt_symbol( uint8_t token_decimal_places, chain::database* db )
 {
    // The list of available nais is not dependent on SMT desired precision (token_decimal_places).
@@ -236,6 +237,7 @@ asset_symbol_type database_fixture::get_new_smt_symbol( uint8_t token_decimal_pl
    // Note that token's precision is needed now, when creating actual symbol.
    return asset_symbol_type::from_nai( new_nai.to_nai(), token_decimal_places );
 }
+#endif
 
 string database_fixture::generate_anon_acct_name()
 {

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -206,7 +206,9 @@ struct database_fixture {
 
    static fc::ecc::private_key generate_private_key( string seed = "init_key" );
    static asset_symbol_type name_to_asset_symbol( const std::string& name, uint8_t decimal_places );
+#ifdef STEEM_ENABLE_SMT
    static asset_symbol_type get_new_smt_symbol( uint8_t token_decimal_places, chain::database* db );
+#endif
    string generate_anon_acct_name();
    void open_database();
    void generate_block(uint32_t skip = 0,

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -206,6 +206,7 @@ struct database_fixture {
 
    static fc::ecc::private_key generate_private_key( string seed = "init_key" );
    static asset_symbol_type name_to_asset_symbol( const std::string& name, uint8_t decimal_places );
+   static asset_symbol_type get_new_smt_symbol( uint8_t token_decimal_places, chain::database* db );
    string generate_anon_acct_name();
    void open_database();
    void generate_block(uint32_t skip = 0,

--- a/tests/tests/smt_operation_tests.cpp
+++ b/tests/tests/smt_operation_tests.cpp
@@ -990,8 +990,8 @@ BOOST_AUTO_TEST_CASE( claim_reward_balance2_validate )
       op.reward_tokens.push_back( ASSET( "1.000 TESTS" ) );
       op.reward_tokens.push_back( ASSET( "1.000000 VESTS" ) );
       op.reward_tokens.push_back( asset( 1, smt1 ) );
-      op.reward_tokens.push_back( asset( 1, smt3 ) );
       op.reward_tokens.push_back( asset( 1, smt2 ) );
+      op.reward_tokens.push_back( asset( 1, smt3 ) );
       op.validate();
       op.reward_tokens.clear();
 
@@ -1122,8 +1122,8 @@ BOOST_AUTO_TEST_CASE( claim_reward_balance2_apply )
       op.reward_tokens.clear();
       // SMTs
       op.reward_tokens.push_back( asset( 0, smt1 ) );
-      op.reward_tokens.push_back( asset( 20*std::pow(10, smt3.decimals()), smt3 ) );
       op.reward_tokens.push_back( asset( 0, smt2 ) );
+      op.reward_tokens.push_back( asset( 20*std::pow(10, smt3.decimals()), smt3 ) );
       FAIL_WITH_OP(op, alice_private_key, fc::assert_exception);
       op.reward_tokens.clear();
 
@@ -1147,12 +1147,12 @@ BOOST_AUTO_TEST_CASE( claim_reward_balance2_apply )
       // SMTs
       asset partial_smt2 = asset( 5*std::pow(10, smt2.decimals()), smt2 );
       op.reward_tokens.push_back( asset( 0, smt1 ) );
-      op.reward_tokens.push_back( asset( 0, smt3 ) );
       op.reward_tokens.push_back( partial_smt2 );
+      op.reward_tokens.push_back( asset( 0, smt3 ) );
       PUSH_OP(op, alice_private_key);
       BOOST_REQUIRE( db->get_balance( "alice", smt1 ) == alice_smt1 + asset( 0, smt1 ) );
-      BOOST_REQUIRE( db->get_balance( "alice", smt3 ) == alice_smt3 + asset( 0, smt3 ) );
       BOOST_REQUIRE( db->get_balance( "alice", smt2 ) == alice_smt2 + partial_smt2 );
+      BOOST_REQUIRE( db->get_balance( "alice", smt3 ) == alice_smt3 + asset( 0, smt3 ) );
       validate_database();
       alice_smt2 += partial_smt2;
       op.reward_tokens.clear();
@@ -1178,12 +1178,12 @@ BOOST_AUTO_TEST_CASE( claim_reward_balance2_apply )
       asset full_smt1 = asset( 10*std::pow(10, smt1.decimals()), smt1 );
       asset full_smt3 = asset( 10*std::pow(10, smt3.decimals()), smt3 );
       op.reward_tokens.push_back( full_smt1 );
-      op.reward_tokens.push_back( full_smt3 );
       op.reward_tokens.push_back( partial_smt2 );
+      op.reward_tokens.push_back( full_smt3 );
       PUSH_OP(op, alice_private_key);
       BOOST_REQUIRE( db->get_balance( "alice", smt1 ) == alice_smt1 + full_smt1 );
-      BOOST_REQUIRE( db->get_balance( "alice", smt3 ) == alice_smt3 + full_smt3 );
       BOOST_REQUIRE( db->get_balance( "alice", smt2 ) == alice_smt2 + partial_smt2 );
+      BOOST_REQUIRE( db->get_balance( "alice", smt3 ) == alice_smt3 + full_smt3 );
       validate_database();
    }
    FC_LOG_AND_RETHROW()


### PR DESCRIPTION
Note, as described in base issue "As part of this issue implementation I had to add `database_fixture::get_new_smt_symbol` as a replacement to `database_fixture::name_to_asset_symbol` as the latter one, once created as stopgap solution (until `get_smt_next_identifier` is ready) is now obsolete and returns invalid symbols."
 #2021 