### PR TITLE
Rocksdb static deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,12 +257,6 @@ endif()
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing -Werror -DBOOST_THREAD_DONT_PROVIDE_PROMISE_LAZY" )
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing -Werror -DBOOST_THREAD_DONT_PROVIDE_PROMISE_LAZY" )
 
-#Configure needed build options of RocksDB.
-SET(WITH_TESTS OFF CACHE BOOL "build with tests")
-SET(WITH_SNAPPY ON CACHE BOOL "build with SNAPPY")
-SET(WITH_ZLIB ON CACHE BOOL "build with ZLIB")
-SET(WITH_BZ2 ON CACHE BOOL "build with BZ2")
-
 # external_plugins needs to be compiled first because libraries/app depends on STEEM_EXTERNAL_PLUGINS being fully populated
 add_subdirectory( external_plugins )
 add_subdirectory( libraries )

--- a/libraries/vendor/CMakeLists.txt
+++ b/libraries/vendor/CMakeLists.txt
@@ -1,4 +1,8 @@
 # for each subdirectory containing a CMakeLists.txt, add that subdirectory
+
+SET(old_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
+SET(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
+
 file( GLOB children RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} * )
 foreach( child ${children} )
    if( IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${child}" )
@@ -7,3 +11,5 @@ foreach( child ${children} )
       endif()
    endif()
 endforeach()
+
+SET(CMAKE_FIND_LIBRARY_SUFFIXES ${old_suffixes})

--- a/libraries/vendor/CMakeLists.txt
+++ b/libraries/vendor/CMakeLists.txt
@@ -1,7 +1,13 @@
 # for each subdirectory containing a CMakeLists.txt, add that subdirectory
 
-SET(old_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
-SET(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
+set(BUILD_SHARED_LIBS OFF)
+
+#Configure needed build options of RocksDB.
+SET(WITH_TESTS OFF CACHE BOOL "build with tests")
+SET(WITH_SNAPPY ON CACHE BOOL "build with SNAPPY")
+SET(WITH_ZLIB ON CACHE BOOL "build with ZLIB")
+SET(WITH_BZ2 ON CACHE BOOL "build with BZ2")
+SET(WITH_BENCHMARKS OFF CACHE BOOL "build with BENCHMARKS")
 
 file( GLOB children RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} * )
 foreach( child ${children} )
@@ -12,4 +18,3 @@ foreach( child ${children} )
    endif()
 endforeach()
 
-SET(CMAKE_FIND_LIBRARY_SUFFIXES ${old_suffixes})

--- a/libraries/vendor/rocksdb/CMakeLists.txt
+++ b/libraries/vendor/rocksdb/CMakeLists.txt
@@ -41,6 +41,10 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules/")
 
+if(NOT BUILD_SHARED_LIBS)
+   set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
+endif()
+
 option(WITH_JEMALLOC "build with JeMalloc" OFF)
 if(MSVC)
   include(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty.inc)
@@ -598,17 +602,22 @@ if(WIN32)
   set(LIBS ${ROCKSDB_STATIC_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
 else()
   set(SYSTEM_LIBS ${CMAKE_THREAD_LIBS_INIT})
-  set(LIBS ${ROCKSDB_SHARED_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
 
-  add_library(${ROCKSDB_SHARED_LIB} SHARED ${SOURCES})
-  target_link_libraries(${ROCKSDB_SHARED_LIB}
-    ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
-  set_target_properties(${ROCKSDB_SHARED_LIB} PROPERTIES
-                        LINKER_LANGUAGE CXX
-                        VERSION ${ROCKSDB_VERSION}
-                        SOVERSION ${ROCKSDB_VERSION_MAJOR}
-                        CXX_STANDARD 11
-                        OUTPUT_NAME "rocksdb")
+  if(BUILD_SHARED_LIBS)
+      set(LIBS ${ROCKSDB_SHARED_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+
+      add_library(${ROCKSDB_SHARED_LIB} SHARED ${SOURCES})
+      target_link_libraries(${ROCKSDB_SHARED_LIB}
+         ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+      set_target_properties(${ROCKSDB_SHARED_LIB} PROPERTIES
+                              LINKER_LANGUAGE CXX
+                              VERSION ${ROCKSDB_VERSION}
+                              SOVERSION ${ROCKSDB_VERSION_MAJOR}
+                              CXX_STANDARD 11
+                              OUTPUT_NAME "rocksdb")
+   else()
+      set(LIBS ${ROCKSDB_STATIC_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+   endif(BUILD_SHARED_LIBS)
 endif()
 
 option(WITH_LIBRADOS "Build with librados" OFF)
@@ -619,8 +628,12 @@ if(WITH_LIBRADOS)
 endif()
 
 add_library(${ROCKSDB_STATIC_LIB} STATIC ${SOURCES})
+
 target_link_libraries(${ROCKSDB_STATIC_LIB}
-  ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+   ${THIRDPARTY_LIBS}
+   ${SYSTEM_LIBS}
+)
+
 
 if(WIN32)
   add_library(${ROCKSDB_IMPORT_LIB} SHARED ${SOURCES})
@@ -682,14 +695,16 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   )
 
-  install(
-    TARGETS ${ROCKSDB_SHARED_LIB}
-    EXPORT RocksDBTargets
-    COMPONENT runtime
-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-  )
+  if(BUILD_SHARED_LIBS)
+      install(
+         TARGETS ${ROCKSDB_SHARED_LIB}
+         EXPORT RocksDBTargets
+         COMPONENT runtime
+         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+         INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+      )
+  endif()
 
   install(
     EXPORT RocksDBTargets
@@ -849,20 +864,23 @@ if(WITH_TESTS)
     list(APPEND TESTS utilities/env_librados_test.cc)
   endif()
 
-  set(BENCHMARKS
-    cache/cache_bench.cc
-    memtable/memtablerep_bench.cc
-    tools/db_bench.cc
-    table/table_reader_bench.cc
-    utilities/column_aware_encoding_exp.cc
-    utilities/persistent_cache/hash_table_bench.cc)
-  add_library(testharness OBJECT util/testharness.cc)
-  foreach(sourcefile ${BENCHMARKS})
-    get_filename_component(exename ${sourcefile} NAME_WE)
-    add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile}
-      $<TARGET_OBJECTS:testharness>)
-    target_link_libraries(${exename}${ARTIFACT_SUFFIX} gtest ${LIBS})
-  endforeach(sourcefile ${BENCHMARKS})
+  option(WITH_BENCHMARKS "build with BENCHMARKS" ON)
+  IF(WITH_BENCHMARKS)
+      set(BENCHMARKS
+         cache/cache_bench.cc
+         memtable/memtablerep_bench.cc
+         tools/db_bench.cc
+         table/table_reader_bench.cc
+         utilities/column_aware_encoding_exp.cc
+         utilities/persistent_cache/hash_table_bench.cc)
+      add_library(testharness OBJECT util/testharness.cc)
+      foreach(sourcefile ${BENCHMARKS})
+         get_filename_component(exename ${sourcefile} NAME_WE)
+         add_executable(${exename}${ARTIFACT_SUFFIX} ${sourcefile}
+            $<TARGET_OBJECTS:testharness>)
+         target_link_libraries(${exename}${ARTIFACT_SUFFIX} gtest ${LIBS})
+      endforeach(sourcefile ${BENCHMARKS})
+  ENDIF(WITH_BENCHMARKS)
 
   # For test util library that is build only in DEBUG mode
   # and linked to tests. Add test only code that is not #ifdefed for Release here.


### PR DESCRIPTION
Fixes related to linking RocksDB dependencies. Right now they are linked statically.
Also redundant compilation of RocksDB has been eliminated (previously it was done once for static and second for shared library).
Additionally, build of benchmarking tools is right now optional (and disabled) since steemd does not need them usually.