### PR TITLE
Fix broken claim_reward_balance2_operation

### DIFF
--- a/libraries/protocol/include/steem/protocol/operations.hpp
+++ b/libraries/protocol/include/steem/protocol/operations.hpp
@@ -62,15 +62,14 @@ namespace steem { namespace protocol {
             reset_account_operation,
             set_reset_account_operation,
             claim_reward_balance_operation,
-#ifdef STEEM_ENABLE_SMT
-            claim_reward_balance2_operation,
-#endif
             delegate_vesting_shares_operation,
             account_create_with_delegation_operation,
             witness_set_properties_operation,
 
 #ifdef STEEM_ENABLE_SMT
             /// SMT operations
+            claim_reward_balance2_operation,
+
             smt_setup_operation,
             smt_cap_reveal_operation,
             smt_refund_operation,


### PR DESCRIPTION
I found that the main chain doesn't replay when SMT's are enabled.  This is because one of the SMT conditionals in `operations.hpp` changes the operation numbering.