### PR TITLE
2302 rocksdb shutdown supplement

### DIFF
--- a/libraries/appbase/application.cpp
+++ b/libraries/appbase/application.cpp
@@ -198,6 +198,11 @@ void application::quit() {
 }
 
 void application::exec() {
+   /** To avoid killing process by broken pipe and continue regular app shutdown.
+    *  Useful for usecase: `steemd | tee steemd.log` and pressing Ctrl+C
+    **/
+   signal(SIGPIPE, SIG_IGN);
+
    std::shared_ptr<boost::asio::signal_set> sigint_set(new boost::asio::signal_set(*io_serv, SIGINT));
    sigint_set->async_wait([sigint_set,this](const boost::system::error_code& err, int num) {
      quit();

--- a/libraries/net/include/graphene/net/message_oriented_connection.hpp
+++ b/libraries/net/include/graphene/net/message_oriented_connection.hpp
@@ -53,7 +53,7 @@ namespace graphene { namespace net {
 
        void send_message(const message& message_to_send);
        void close_connection();
-       void destroy_connection();
+       void destroy_connection(const char* caller);
 
        uint64_t       get_total_bytes_sent() const;
        uint64_t       get_total_bytes_received() const;

--- a/libraries/net/include/graphene/net/peer_connection.hpp
+++ b/libraries/net/include/graphene/net/peer_connection.hpp
@@ -274,7 +274,7 @@ namespace graphene { namespace net
       bool _currently_handling_message = false; // true while we're in the middle of handling a message from the remote system
     private:
       peer_connection(peer_connection_delegate* delegate);
-      void destroy();
+      void destroy(const char* caller);
     public:
       static peer_connection_ptr make_shared(peer_connection_delegate* delegate); // use this instead of the constructor
       virtual ~peer_connection();
@@ -290,7 +290,7 @@ namespace graphene { namespace net
       void send_message(const message& message_to_send, size_t message_send_time_field_offset = (size_t)-1);
       void send_item(const item_id& item_to_send);
       void close_connection();
-      void destroy_connection();
+      void destroy_connection(const char* caller);
 
       uint64_t get_total_bytes_sent() const;
       uint64_t get_total_bytes_received() const;

--- a/libraries/net/message_oriented_connection.cpp
+++ b/libraries/net/message_oriented_connection.cpp
@@ -128,7 +128,7 @@ namespace graphene { namespace net {
     {
       VERIFY_CORRECT_THREAD();
       _sock.connect_to(remote_endpoint);
-      assert(!_read_loop_done.valid()); // check to be sure we never launch two read loops
+      FC_ASSERT(!_read_loop_done.valid()); // check to be sure we never launch two read loops
       _read_loop_done = fc::async([=](){ read_loop(); }, "message read_loop");
     }
 

--- a/libraries/net/message_oriented_connection.cpp
+++ b/libraries/net/message_oriented_connection.cpp
@@ -81,7 +81,7 @@ namespace graphene { namespace net {
 
       void send_message(const message& message_to_send);
       void close_connection();
-      void destroy_connection();
+      void destroy_connection(const char* caller);
 
       uint64_t get_total_bytes_sent() const;
       uint64_t get_total_bytes_received() const;
@@ -107,7 +107,7 @@ namespace graphene { namespace net {
     message_oriented_connection_impl::~message_oriented_connection_impl()
     {
       VERIFY_CORRECT_THREAD();
-      destroy_connection();
+      destroy_connection(__FUNCTION__);
     }
 
     fc::tcp_socket& message_oriented_connection_impl::get_socket()
@@ -281,14 +281,14 @@ namespace graphene { namespace net {
       _sock.close();
     }
 
-    void message_oriented_connection_impl::destroy_connection()
+    void message_oriented_connection_impl::destroy_connection(const char* caller)
     {
       VERIFY_CORRECT_THREAD();
 
       fc::optional<fc::ip::endpoint> remote_endpoint;
       if (_sock.get_socket().is_open())
         remote_endpoint = _sock.get_socket().remote_endpoint();
-      ilog( "in destroy_connection() for ${endpoint}", ("endpoint", remote_endpoint) );
+      ilog( "in destroy_connection(${caller}) for `${endpoint}'", ("caller", caller)("endpoint", remote_endpoint) );
 
       if (_send_message_in_progress)
         elog("Error: message_oriented_connection is being destroyed while a send_message is in progress.  "
@@ -381,9 +381,9 @@ namespace graphene { namespace net {
     my->close_connection();
   }
 
-  void message_oriented_connection::destroy_connection()
+  void message_oriented_connection::destroy_connection(const char* caller)
   {
-    my->destroy_connection();
+    my->destroy_connection(caller);
   }
 
   uint64_t message_oriented_connection::get_total_bytes_sent() const

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -801,7 +801,8 @@ namespace graphene { namespace net {
       _average_network_write_speed_hours(72),
       _average_network_usage_second_counter(0),
       _average_network_usage_minute_counter(0),
-      _node_is_shutting_down(false)
+      _node_is_shutting_down(false),
+      _activeCalls(0)
     {
       _rate_limiter.set_actual_rate_time_constant(fc::seconds(2));
       fc::rand_pseudo_bytes(&_node_id.data[0], (int)_node_id.size());

--- a/libraries/net/node.cpp
+++ b/libraries/net/node.cpp
@@ -744,7 +744,37 @@ namespace graphene { namespace net {
       private:
          node_impl& _node;
          bool       _notify;
-      };
+      }; /// activity_tracer
+
+#ifdef P2P_IN_DEDICATED_THREAD
+# define VERIFY_CORRECT_THREAD() assert(_thread->is_current())
+#else
+# define VERIFY_CORRECT_THREAD() do {} while (0)
+#endif
+
+      template<typename Functor>
+      auto async_task( Functor&& f, const char* desc FC_TASK_NAME_DEFAULT_ARG, fc::priority prio = fc::priority()) -> fc::future<decltype(f())> {
+         auto wrapper = [this, desc, f]() -> decltype(f())
+         {
+            VERIFY_CORRECT_THREAD();
+            activity_tracer aTracer(desc, *this);
+            return f();
+         };
+         return fc::async( wrapper, desc, prio );
+      }
+      template<typename Functor>
+      auto schedule_task( Functor&& f, const fc::time_point& t, const char* desc FC_TASK_NAME_DEFAULT_ARG, fc::priority prio = fc::priority()) -> fc::future<decltype(f())>
+      {
+         auto wrapper = [this, desc, f]() -> decltype(f())
+         {
+            VERIFY_CORRECT_THREAD();
+            activity_tracer aTracer(desc, *this);
+            return f();
+         };
+
+         return fc::schedule( wrapper, t, desc, prio );
+      }
+      
    }; // end class node_impl
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -769,12 +799,6 @@ namespace graphene { namespace net {
       delete impl_to_delete;
 #endif // P2P_IN_DEDICATED_THREAD
     }
-
-#ifdef P2P_IN_DEDICATED_THREAD
-# define VERIFY_CORRECT_THREAD() assert(_thread->is_current())
-#else
-# define VERIFY_CORRECT_THREAD() do {} while (0)
-#endif
 
     node_impl::node_impl(const std::string& user_agent) :
 #ifdef P2P_IN_DEDICATED_THREAD
@@ -873,8 +897,7 @@ namespace graphene { namespace net {
 
     void node_impl::p2p_network_connect_loop()
     {
-      VERIFY_CORRECT_THREAD();
-      while (!_p2p_network_connect_loop_done.canceled())
+      while (!_p2p_network_connect_loop_done.canceled() && !_node_is_shutting_down)
       {
         try
         {
@@ -926,10 +949,15 @@ namespace graphene { namespace net {
 
             if (!initiated_connection_this_pass && !_potential_peer_database_updated)
               break;
-          }
+          } /// while (is_wanting_new_connections())
 
           display_current_connections();
 
+          if(_node_is_shutting_down)
+          {
+            ilog("Breaking p2p_network_connect_loop loop because node is shutting down");
+            break;
+          }
           // if we broke out of the while loop, that means either we have connected to enough nodes, or
           // we don't have any good candidates to connect to right now.
 #if 0
@@ -1013,7 +1041,6 @@ namespace graphene { namespace net {
 
     void node_impl::fetch_sync_items_loop()
     {
-      VERIFY_CORRECT_THREAD();
       while( !_fetch_sync_items_loop_done.canceled() )
       {
         _sync_items_to_fetch_updated = false;
@@ -1096,7 +1123,6 @@ namespace graphene { namespace net {
 
     void node_impl::fetch_items_loop()
     {
-      VERIFY_CORRECT_THREAD();
       while (!_fetch_item_loop_done.canceled())
       {
         _items_to_fetch_updated = false;
@@ -1231,7 +1257,6 @@ namespace graphene { namespace net {
 
     void node_impl::advertise_inventory_loop()
     {
-      VERIFY_CORRECT_THREAD();
       while (!_advertise_inventory_loop_done.canceled())
       {
         dlog("beginning an iteration of advertise inventory");
@@ -1306,7 +1331,6 @@ namespace graphene { namespace net {
 
     void node_impl::terminate_inactive_connections_loop()
     {
-      VERIFY_CORRECT_THREAD();
       std::list<peer_connection_ptr> peers_to_disconnect_gently;
       std::list<peer_connection_ptr> peers_to_disconnect_forcibly;
       std::list<peer_connection_ptr> peers_to_send_keep_alive;
@@ -1504,15 +1528,13 @@ namespace graphene { namespace net {
       peers_to_send_keep_alive.clear();
 
       if (!_node_is_shutting_down && !_terminate_inactive_connections_loop_done.canceled())
-         _terminate_inactive_connections_loop_done = fc::schedule( [this](){ terminate_inactive_connections_loop(); },
+         _terminate_inactive_connections_loop_done = schedule_task( [this](){ terminate_inactive_connections_loop(); },
                                                                    fc::time_point::now() + fc::seconds(1),
                                                                    "terminate_inactive_connections_loop" );
     }
 
     void node_impl::fetch_updated_peer_lists_loop()
     {
-      VERIFY_CORRECT_THREAD();
-
       std::list<peer_connection_ptr> original_active_peers(_active_connections.begin(), _active_connections.end());
       for( const peer_connection_ptr& active_peer : original_active_peers )
       {
@@ -1539,7 +1561,7 @@ namespace graphene { namespace net {
       _recently_failed_items.get<peer_connection::timestamp_index>().erase(begin_iter, oldest_failed_ids_to_keep_iter);
 
       if (!_node_is_shutting_down && !_fetch_updated_peer_lists_loop_done.canceled() )
-         _fetch_updated_peer_lists_loop_done = fc::schedule( [this](){ fetch_updated_peer_lists_loop(); },
+         _fetch_updated_peer_lists_loop_done = schedule_task( [this](){ fetch_updated_peer_lists_loop(); },
                                                              fc::time_point::now() + fc::minutes(GRAPHENE_NET_FETCH_UPDATED_PEER_LISTS_INTERVAL_MINUTES),
                                                              "fetch_updated_peer_lists_loop" );
     }
@@ -1569,7 +1591,6 @@ namespace graphene { namespace net {
     }
     void node_impl::bandwidth_monitor_loop()
     {
-      VERIFY_CORRECT_THREAD();
       fc::time_point_sec current_time = fc::time_point::now();
 
       if (_bandwidth_monitor_last_update_time == fc::time_point_sec::min())
@@ -1585,24 +1606,22 @@ namespace graphene { namespace net {
       _bandwidth_monitor_last_update_time = current_time;
 
       if (!_node_is_shutting_down && !_bandwidth_monitor_loop_done.canceled())
-        _bandwidth_monitor_loop_done = fc::schedule( [=](){ bandwidth_monitor_loop(); },
+        _bandwidth_monitor_loop_done = schedule_task( [=](){ bandwidth_monitor_loop(); },
                                                      fc::time_point::now() + fc::seconds(GRAPHENE_NET_BANDWIDTH_MONITOR_INTERVAL_SECONDS),
                                                      "bandwidth_monitor_loop" );
     }
 
     void node_impl::dump_node_status_task()
     {
-      VERIFY_CORRECT_THREAD();
       dump_node_status();
       if (!_node_is_shutting_down && !_dump_node_status_task_done.canceled())
-        _dump_node_status_task_done = fc::schedule([=](){ dump_node_status_task(); },
+        _dump_node_status_task_done = schedule_task([=](){ dump_node_status_task(); },
                                                    fc::time_point::now() + fc::minutes(GRAPHENE_NET_DUMP_NODE_STATUS_INTERVAL_MINUTES),
                                                    "dump_node_status_task");
     }
 
     void node_impl::delayed_peer_deletion_task()
     {
-      VERIFY_CORRECT_THREAD();
 #ifdef USE_PEERS_TO_DELETE_MUTEX
       fc::scoped_lock<fc::mutex> lock(_peers_to_delete_mutex);
       dlog("in delayed_peer_deletion_task with ${count} in queue", ("count", _peers_to_delete.size()));
@@ -1643,7 +1662,7 @@ namespace graphene { namespace net {
           (!_delayed_peer_deletion_task_done.valid() || _delayed_peer_deletion_task_done.ready()))
       {
         dlog("asyncing delayed_peer_deletion_task to delete ${size} peers", ("size", number_of_peers_to_delete));
-        _delayed_peer_deletion_task_done = fc::async([this](){ delayed_peer_deletion_task(); }, "delayed_peer_deletion_task" );
+        _delayed_peer_deletion_task_done = async_task([this](){ delayed_peer_deletion_task(); }, "delayed_peer_deletion_task" );
     }
       else
         dlog("delayed_peer_deletion_task is already scheduled (current size of _peers_to_delete is ${size})", ("size", number_of_peers_to_delete));
@@ -1654,7 +1673,7 @@ namespace graphene { namespace net {
           (!_delayed_peer_deletion_task_done.valid() || _delayed_peer_deletion_task_done.ready()))
       {
         dlog("asyncing delayed_peer_deletion_task to delete ${size} peers", ("size", _peers_to_delete.size()));
-        _delayed_peer_deletion_task_done = fc::async([this](){ delayed_peer_deletion_task(); }, "delayed_peer_deletion_task" );
+        _delayed_peer_deletion_task_done = async_task([this](){ delayed_peer_deletion_task(); }, "delayed_peer_deletion_task" );
       }
       else
         dlog("delayed_peer_deletion_task is already scheduled (current size of _peers_to_delete is ${size})", ("size", _peers_to_delete.size()));
@@ -1665,13 +1684,15 @@ namespace graphene { namespace net {
     bool node_impl::is_accepting_new_connections()
     {
       VERIFY_CORRECT_THREAD();
-      return !_p2p_network_connect_loop_done.canceled() && get_number_of_connections() <= _node_configuration.maximum_number_of_connections;
+      return !_node_is_shutting_down && !_p2p_network_connect_loop_done.canceled() &&
+         get_number_of_connections() <= _node_configuration.maximum_number_of_connections;
     }
 
     bool node_impl::is_wanting_new_connections()
     {
       VERIFY_CORRECT_THREAD();
-      return !_p2p_network_connect_loop_done.canceled() && get_number_of_connections() < _node_configuration.desired_number_of_connections;
+      return !_node_is_shutting_down && !_p2p_network_connect_loop_done.canceled() &&
+         get_number_of_connections() < _node_configuration.desired_number_of_connections;
     }
 
     uint32_t node_impl::get_number_of_connections()
@@ -3070,6 +3091,7 @@ namespace graphene { namespace net {
     void node_impl::send_sync_block_to_node_delegate(const graphene::net::block_message& block_message_to_send)
     {
       dlog("in send_sync_block_to_node_delegate()");
+
       bool client_accepted_block = false;
       bool discontinue_fetching_blocks_from_peer = false;
 
@@ -3253,13 +3275,12 @@ namespace graphene { namespace net {
       if (// _suspend_fetching_sync_blocks && <-- you can use this if "maximum_number_of_blocks_to_handle_at_one_time" == "maximum_number_of_sync_blocks_to_prefetch"
           !_node_is_shutting_down &&
           (!_process_backlog_of_sync_blocks_done.valid() || _process_backlog_of_sync_blocks_done.ready()))
-        _process_backlog_of_sync_blocks_done = fc::async([=](){ process_backlog_of_sync_blocks(); },
-                                                         "process_backlog_of_sync_blocks");
+        _process_backlog_of_sync_blocks_done = async_task([=](){ process_backlog_of_sync_blocks(); },
+                                                          "process_backlog_of_sync_blocks");
     }
 
     void node_impl::process_backlog_of_sync_blocks()
     {
-      VERIFY_CORRECT_THREAD();
       // garbage-collect the list of async tasks here for lack of a better place
       for (auto calls_iter = _handle_message_calls_in_progress.begin();
             calls_iter != _handle_message_calls_in_progress.end();)
@@ -3342,7 +3363,7 @@ namespace graphene { namespace net {
             {
               graphene::net::block_message block_message_to_process = *received_block_iter;
               _received_sync_items.erase(received_block_iter);
-              _handle_message_calls_in_progress.emplace_back(fc::async([this, block_message_to_process](){
+              _handle_message_calls_in_progress.emplace_back(async_task([this, block_message_to_process](){
                 send_sync_block_to_node_delegate(block_message_to_process);
               }, "send_sync_block_to_node_delegate"));
               ++blocks_processed;
@@ -3403,13 +3424,12 @@ namespace graphene { namespace net {
     {
       if (!_node_is_shutting_down &&
           (!_process_backlog_of_sync_blocks_done.valid() || _process_backlog_of_sync_blocks_done.ready()))
-        _process_backlog_of_sync_blocks_done = fc::async([=](){ process_backlog_of_sync_blocks(); }, "process_backlog_of_sync_blocks");
+        _process_backlog_of_sync_blocks_done = async_task([=](){ process_backlog_of_sync_blocks(); }, "process_backlog_of_sync_blocks");
     }
 
     void node_impl::process_block_during_sync( peer_connection* originating_peer,
                                                const graphene::net::block_message& block_message_to_process, const message_hash_type& message_hash )
     {
-      VERIFY_CORRECT_THREAD();
       dlog( "received a sync block from peer ${endpoint}", ("endpoint", originating_peer->get_remote_endpoint() ) );
 
       // add it to the front of _received_sync_items, then process _received_sync_items to try to
@@ -4214,7 +4234,7 @@ namespace graphene { namespace net {
          {
          try
          {
-            peer->destroy_connection();
+            peer->destroy_connection(__FUNCTION__);
          }
          catch ( const fc::exception& e )
          {
@@ -4269,6 +4289,8 @@ namespace graphene { namespace net {
       {
         wlog( "Exception thrown while terminating Terminate inactive connections loop, ignoring" );
       }
+      /// Clear container to immediately deallocate held peer_connection::ptr objects
+      _terminating_connections.clear();
 
       try
       {
@@ -4315,14 +4337,12 @@ namespace graphene { namespace net {
 
     void node_impl::accept_connection_task( peer_connection_ptr new_peer )
     {
-      VERIFY_CORRECT_THREAD();
       new_peer->accept_connection(); // this blocks until the secure connection is fully negotiated
       send_hello_message(new_peer);
     }
 
     void node_impl::accept_loop()
     {
-      VERIFY_CORRECT_THREAD();
       while ( !_accept_loop_complete.canceled() )
       {
         peer_connection_ptr new_peer(peer_connection::make_shared(this));
@@ -4337,7 +4357,7 @@ namespace graphene { namespace net {
           _handshaking_connections.insert( new_peer );
           _rate_limiter.add_tcp_socket( &new_peer->get_socket() );
           std::weak_ptr<peer_connection> new_weak_peer(new_peer);
-          new_peer->accept_or_connect_task_done = fc::async( [this, new_weak_peer]() {
+          new_peer->accept_or_connect_task_done = async_task( [this, new_weak_peer]() {
             peer_connection_ptr new_peer(new_weak_peer.lock());
             assert(new_peer);
             if (!new_peer)
@@ -4695,15 +4715,15 @@ namespace graphene { namespace net {
              !_bandwidth_monitor_loop_done.valid() &&
              !_dump_node_status_task_done.valid());
       if (_node_configuration.accept_incoming_connections)
-        _accept_loop_complete = fc::async( [=](){ accept_loop(); }, "accept_loop");
-      _p2p_network_connect_loop_done = fc::async( [=]() { p2p_network_connect_loop(); }, "p2p_network_connect_loop" );
-      _fetch_sync_items_loop_done = fc::async( [=]() { fetch_sync_items_loop(); }, "fetch_sync_items_loop" );
-      _fetch_item_loop_done = fc::async( [=]() { fetch_items_loop(); }, "fetch_items_loop" );
-      _advertise_inventory_loop_done = fc::async( [=]() { advertise_inventory_loop(); }, "advertise_inventory_loop" );
-      _terminate_inactive_connections_loop_done = fc::async( [=]() { terminate_inactive_connections_loop(); }, "terminate_inactive_connections_loop" );
-      _fetch_updated_peer_lists_loop_done = fc::async([=](){ fetch_updated_peer_lists_loop(); }, "fetch_updated_peer_lists_loop");
-      _bandwidth_monitor_loop_done = fc::async([=](){ bandwidth_monitor_loop(); }, "bandwidth_monitor_loop");
-      _dump_node_status_task_done = fc::async([=](){ dump_node_status_task(); }, "dump_node_status_task");
+        _accept_loop_complete = async_task( [=](){ accept_loop(); }, "accept_loop");
+      _p2p_network_connect_loop_done = async_task( [=]() { p2p_network_connect_loop(); }, "p2p_network_connect_loop" );
+      _fetch_sync_items_loop_done = async_task( [=]() { fetch_sync_items_loop(); }, "fetch_sync_items_loop" );
+      _fetch_item_loop_done = async_task( [=]() { fetch_items_loop(); }, "fetch_items_loop" );
+      _advertise_inventory_loop_done = async_task( [=]() { advertise_inventory_loop(); }, "advertise_inventory_loop" );
+      _terminate_inactive_connections_loop_done = async_task( [=]() { terminate_inactive_connections_loop(); }, "terminate_inactive_connections_loop" );
+      _fetch_updated_peer_lists_loop_done = async_task([=](){ fetch_updated_peer_lists_loop(); }, "fetch_updated_peer_lists_loop");
+      _bandwidth_monitor_loop_done = async_task([=](){ bandwidth_monitor_loop(); }, "bandwidth_monitor_loop");
+      _dump_node_status_task_done = async_task([=](){ dump_node_status_task(); }, "dump_node_status_task");
     }
 
     void node_impl::add_node(const fc::ip::endpoint& ep)
@@ -4733,7 +4753,8 @@ namespace graphene { namespace net {
         return;
 
       std::weak_ptr<peer_connection> new_weak_peer(new_peer);
-      new_peer->accept_or_connect_task_done = fc::async([this, new_weak_peer](){
+      new_peer->accept_or_connect_task_done = async_task([this, new_weak_peer]()
+      {
         peer_connection_ptr new_peer(new_weak_peer.lock());
         assert(new_peer);
         if (!new_peer)

--- a/libraries/net/peer_connection.cpp
+++ b/libraries/net/peer_connection.cpp
@@ -110,7 +110,7 @@ namespace graphene { namespace net
       //, [](peer_connection* peer_to_delete){ fc::async([peer_to_delete](){delete peer_to_delete;}); });
     }
 
-    void peer_connection::destroy()
+    void peer_connection::destroy(const char* caller)
     {
       VERIFY_CORRECT_THREAD();
 
@@ -169,13 +169,13 @@ namespace graphene { namespace net
         wlog("Unexpected exception from peer_connection's accept_or_connect_task");
       }
 
-      _message_connection.destroy_connection(); // shut down the read loop
+      _message_connection.destroy_connection(caller); // shut down the read loop
     }
 
     peer_connection::~peer_connection()
     {
       VERIFY_CORRECT_THREAD();
-      destroy();
+      destroy(__FUNCTION__);
     }
 
     fc::tcp_socket& peer_connection::get_socket()
@@ -396,11 +396,11 @@ namespace graphene { namespace net
       _message_connection.close_connection();
     }
 
-    void peer_connection::destroy_connection()
+    void peer_connection::destroy_connection(const char* caller)
     {
       VERIFY_CORRECT_THREAD();
       negotiation_status = connection_negotiation_status::closing;
-      destroy();
+      destroy(caller);
     }
 
     uint64_t peer_connection::get_total_bytes_sent() const

--- a/libraries/plugins/p2p/p2p_plugin.cpp
+++ b/libraries/plugins/p2p/p2p_plugin.cpp
@@ -77,7 +77,7 @@ class p2p_plugin_impl : public graphene::net::node_delegate
 public:
 
    p2p_plugin_impl( plugins::chain::chain_plugin& c )
-      : running(true), chain( c )
+      : running(true), activeHandleBlock(false), activeHandleTx(false), chain( c )
    {
       handleBlockFinished.second = std::shared_future<void>(handleBlockFinished.first.get_future());
       handleTxFinished.second = std::shared_future<void>(handleTxFinished.first.get_future());
@@ -139,7 +139,10 @@ private:
       {
          _activityFlag.store(false);
          if(_impl.running.load() == false && _barrier.second.valid() == false)
+         {
+            ilog("Sending notification to shutdown barrier.");
             _barrier.first.set_value();
+         }
       }
 
    private:


### PR DESCRIPTION
Issue #2302
1. Solved synchronization problems during graphene::node shutdown (all async tasks are forcing a node to wait until their finish). To simplify code dedicated methods `async_task`, `schedule_task` have been added, which encapsulate synchronization management.
2. Eliminated superfluous statistic_collector object declaration from `INVOKE_AND_COLLECT_STATISTICS` macro, which caused crash during regular sync (looks like there was uncontrolled write to the same accumulator_set object done by 2 threads).
3. SIGPIPE is ignored by steemd right now to correctly handle SIGINT in case steemd was spawned in pipe ie: `steemd | tee steemd.log`. Previously it was killed (default action for broken pipe) when Ctrl+C was pressed on the tee input.