### PR TITLE
Exchange node config shared file size to 54G

### DIFF
--- a/doc/example_config.ini
+++ b/doc/example_config.ini
@@ -1,6 +1,6 @@
 # this will need to increase depending on which plugins/apis you use
-# 24 GB should be sufficient for a consensus node
-shared-file-size = 24G
+# 54 GB should be sufficient for a consensus node
+shared-file-size = 54G
 
 # Endpoint for P2P node to listen on
 # p2p-endpoint =


### PR DESCRIPTION
In the [exchange quickstart guide](https://github.com/steemit/steem/blob/master/doc/exchangequickstart.md), it references an example config. The example config still has the shared memory size set to 24GB. This pull request updates it to 54GB.