### PR TITLE
add public blocklog option

### DIFF
--- a/contrib/steemd.run
+++ b/contrib/steemd.run
@@ -90,6 +90,18 @@ if [[ "$USE_PUBLIC_SHARED_MEMORY" ]]; then
   wget -qO- https://s3.amazonaws.com/steemit-dev-blockchainstate/blockchain-$VERSION-latest.tar.lz4 | lz4 -d | tar x
 fi
 
+if [[ "$USE_PUBLIC_BLOCKLOG" ]]; then
+  if [[ ! -e $HOME/blockchain/block_log ]]; then
+    if [[ ! -d $HOME/blockchain ]]; then
+      mkdir -p $HOME/blockchain
+    fi
+    echo "steemd: Downloading a block_log and replaying the blockchain"
+    echo "This may take a little while..."
+    wget -O $HOME/blockchain/block_log https://s3.amazonaws.com/steemit-dev-blockchainstate/block_log-latest
+    ARGS+=" --replay-blockchain"
+  fi
+fi
+
 # slow down restart loop if flapping
 sleep 1
 

--- a/contrib/sync-sv-run.sh
+++ b/contrib/sync-sv-run.sh
@@ -87,6 +87,7 @@ if [[ ! -z "$BLOCKCHAIN_TIME" ]]; then
     if [[ ! "$IS_BROADCAST_NODE" ]] && [[ ! "$IS_AH_NODE" ]]; then
       aws s3 cp blockchain/block_log s3://$S3_BUCKET/block_log-intransit
       aws s3 cp s3://$S3_BUCKET/block_log-intransit s3://$S3_BUCKET/block_log-latest
+      aws s3api put-object-acl --bucket $S3_BUCKET --key block_log-latest --acl public-read
     fi
     # kill the container starting the process over again
     echo steemdsync: stopping the container after a sync operation


### PR DESCRIPTION
This updates stable to include the `USE_PUBLIC_BLOCKLOG` option to replay from our public blocklog.