### PR TITLE
Replaced obsolete name_to_asset_symbol with get_new_smt_symbol

### DIFF
--- a/tests/db_fixture/database_fixture.cpp
+++ b/tests/db_fixture/database_fixture.cpp
@@ -211,22 +211,6 @@ fc::ecc::private_key database_fixture::generate_private_key(string seed)
    return fc::ecc::private_key::regenerate( fc::sha256::hash( seed ) );
 }
 
-asset_symbol_type database_fixture::name_to_asset_symbol( const std::string& name, uint8_t decimal_places )
-{
-   // Deterministically turn a name into an asset symbol
-   // Example:
-   // alice -> sha256(alice) -> 2bd806c9... -> 2bd806c9 -> low 27 bits is 64489161 -> add check digit -> @@644891612
-
-   uint32_t h0 = (boost::endian::native_to_big( fc::sha256::hash( name )._hash[0] ) >> 32) & 0x7FFFFFF;
-   FC_ASSERT( decimal_places <= STEEM_ASSET_MAX_DECIMALS, "Invalid decimal_places" );
-   while( h0 > SMT_MAX_NAI )
-      h0 -= SMT_MAX_NAI;
-   while( h0 < SMT_MIN_NAI )
-      h0 += SMT_MIN_NAI;
-   uint32_t asset_num = (h0 << 5) | 0x10 | decimal_places;
-   return asset_symbol_type::from_asset_num( asset_num );
-}
-
 #ifdef STEEM_ENABLE_SMT
 asset_symbol_type database_fixture::get_new_smt_symbol( uint8_t token_decimal_places, chain::database* db )
 {

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -134,8 +134,8 @@ extern uint32_t ( STEEM_TESTING_GENESIS_TIMESTAMP );
 #define ACTORS(names) BOOST_PP_SEQ_FOR_EACH(ACTORS_IMPL, ~, names) \
    validate_database();
 
-#define SMT_SYMBOL( name, decimal_places ) \
-   asset_symbol_type name ## _symbol = name_to_asset_symbol( #name , decimal_places );
+#define SMT_SYMBOL( name, decimal_places, db ) \
+   asset_symbol_type name ## _symbol = get_new_smt_symbol( decimal_places, db );
 
 #define ASSET( s ) \
    steem::plugins::condenser_api::legacy_asset::from_string( s ).to_asset()
@@ -205,7 +205,6 @@ struct database_fixture {
    virtual ~database_fixture() { appbase::reset(); }
 
    static fc::ecc::private_key generate_private_key( string seed = "init_key" );
-   static asset_symbol_type name_to_asset_symbol( const std::string& name, uint8_t decimal_places );
 #ifdef STEEM_ENABLE_SMT
    static asset_symbol_type get_new_smt_symbol( uint8_t token_decimal_places, chain::database* db );
 #endif

--- a/tests/tests/smt_tests.cpp
+++ b/tests/tests/smt_tests.cpp
@@ -24,24 +24,6 @@ using boost::container::flat_map;
 
 BOOST_FIXTURE_TEST_SUITE( smt_tests, smt_database_fixture )
 
-BOOST_AUTO_TEST_CASE( asset_symbol_validate )
-{
-   try
-   {
-      auto check_validate = [&]( const std::string& name, uint8_t decimal_places )
-      {
-         asset_symbol_type sym = name_to_asset_symbol( name, decimal_places );
-         sym.validate();
-      };
-
-      // specific cases in https://github.com/steemit/steem/issues/1738
-      check_validate( "0", 0 );
-      check_validate( "d2", 1 );
-      check_validate( "da1", 1 );
-   }
-   FC_LOG_AND_RETHROW()
-}
-
 BOOST_AUTO_TEST_CASE( smt_create_validate )
 {
    try
@@ -94,7 +76,7 @@ BOOST_AUTO_TEST_CASE( smt_create_authorities )
 {
    try
    {
-      SMT_SYMBOL( alice, 3 );
+      SMT_SYMBOL( alice, 3, db );
 
       smt_create_operation op;
       op.control_account = "alice";
@@ -171,7 +153,7 @@ BOOST_AUTO_TEST_CASE( smt_create_apply )
       unsigned int too_low_fee_amount = required_creation_fee.amount.value-1;
       fee_too_low.amount -= 1;
 
-      SMT_SYMBOL( bob, 0 );
+      SMT_SYMBOL( bob, 0, db );
       op.control_account = "bob";
       op.symbol = bob_symbol;
       op.precision = op.symbol.decimals();
@@ -283,7 +265,7 @@ BOOST_AUTO_TEST_CASE( setup_emissions_authorities )
 {
    try
    {
-      SMT_SYMBOL( alice, 3 );
+      SMT_SYMBOL( alice, 3, db );
 
       smt_setup_emissions_operation op;
       op.control_account = "alice";


### PR DESCRIPTION
 #2124
Note that I removed regression  test `asset_symbol_validate` that was created specifically to test a bug in replaced `name_to_asset_symbol` and has nothing to test now.