### PR TITLE
Implement additional per-block stats

### DIFF
--- a/libraries/plugins/block_data_export/include/steem/plugins/block_data_export/block_data_export_plugin.hpp
+++ b/libraries/plugins/block_data_export/include/steem/plugins/block_data_export/block_data_export_plugin.hpp
@@ -73,4 +73,13 @@ class block_data_export_plugin : public appbase::plugin< block_data_export_plugi
       std::unique_ptr< detail::block_data_export_plugin_impl > my;
 };
 
+template< typename T >
+std::shared_ptr< T > find_export_data( const std::string& name )
+{
+   block_data_export_plugin* export_plugin = appbase::app().find_plugin< block_data_export_plugin >();
+   if( export_plugin == nullptr )
+      return std::shared_ptr< T >();
+   return export_plugin->find_export_data< T >( name );
+}
+
 } } } // steem::plugins::block_data_export

--- a/libraries/plugins/block_data_export/include/steem/plugins/block_data_export/exportable_block_data.hpp
+++ b/libraries/plugins/block_data_export/include/steem/plugins/block_data_export/exportable_block_data.hpp
@@ -2,6 +2,10 @@
 
 #include <string>
 
+namespace fc {
+class variant;
+}
+
 namespace steem { namespace plugins { namespace block_data_export {
 
 class exportable_block_data

--- a/libraries/plugins/witness/CMakeLists.txt
+++ b/libraries/plugins/witness/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library( witness_plugin
              ${HEADERS}
            )
 
-target_link_libraries( witness_plugin p2p_plugin chain_plugin appbase steem_chain steem_utilities steem_utilities )
+target_link_libraries( witness_plugin p2p_plugin chain_plugin block_data_export_plugin appbase steem_chain steem_utilities steem_utilities )
 target_include_directories( witness_plugin
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
 

--- a/libraries/plugins/witness/include/steem/plugins/witness/witness_export_objects.hpp
+++ b/libraries/plugins/witness/include/steem/plugins/witness/witness_export_objects.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <steem/plugins/block_data_export/exportable_block_data.hpp>
+#include <steem/plugins/witness/witness_objects.hpp>
+
+namespace steem { namespace plugins { namespace witness {
+
+using steem::plugins::block_data_export::exportable_block_data;
+
+struct exp_bandwidth_update_object
+{
+   exp_bandwidth_update_object();
+   exp_bandwidth_update_object( const account_bandwidth_object& bwo, uint32_t tsize );
+
+   account_name_type account;
+   bandwidth_type    type;
+   share_type        average_bandwidth;
+   share_type        lifetime_bandwidth;
+   time_point_sec    last_bandwidth_update;
+   uint32_t          tx_size = 0;
+};
+
+struct exp_reserve_ratio_object
+{
+   exp_reserve_ratio_object();
+   exp_reserve_ratio_object( const reserve_ratio_object& rr, int32_t block_size );
+
+   int32_t    average_block_size = 0;
+   int64_t    current_reserve_ratio = 1;
+   uint128_t  max_virtual_bandwidth = 0;
+   int32_t    block_size = 0;
+};
+
+class exp_witness_data_object
+   : public exportable_block_data
+{
+   public:
+      exp_witness_data_object();
+      virtual ~exp_witness_data_object();
+
+      virtual void to_variant( fc::variant& v )const override
+      {
+         fc::to_variant( *this, v );
+      }
+
+      std::vector< exp_bandwidth_update_object >            bandwidth_updates;
+      exp_reserve_ratio_object                              reserve_ratio;
+};
+
+} } }
+
+FC_REFLECT( steem::plugins::witness::exp_bandwidth_update_object,
+   (account)
+   (type)
+   (average_bandwidth)
+   (lifetime_bandwidth)
+   (last_bandwidth_update)
+   (tx_size)
+   )
+
+FC_REFLECT( steem::plugins::witness::exp_reserve_ratio_object,
+   (average_block_size)
+   (current_reserve_ratio)
+   (max_virtual_bandwidth)
+   (block_size)
+   )
+
+FC_REFLECT( steem::plugins::witness::exp_witness_data_object,
+   (bandwidth_updates)
+   (reserve_ratio)
+   )

--- a/libraries/plugins/witness/include/steem/plugins/witness/witness_objects.hpp
+++ b/libraries/plugins/witness/include/steem/plugins/witness/witness_objects.hpp
@@ -94,7 +94,6 @@ class reserve_ratio_object : public object< reserve_ratio_object_type, reserve_r
 
 typedef oid< reserve_ratio_object > reserve_ratio_id_type;
 
-
 struct by_account_bandwidth_type;
 
 typedef multi_index_container <

--- a/libraries/plugins/witness/include/steem/plugins/witness/witness_plugin.hpp
+++ b/libraries/plugins/witness/include/steem/plugins/witness/witness_plugin.hpp
@@ -34,7 +34,10 @@ namespace block_production_condition
 class witness_plugin : public appbase::plugin< witness_plugin >
 {
 public:
-   APPBASE_PLUGIN_REQUIRES((steem::plugins::chain::chain_plugin)(steem::plugins::p2p::p2p_plugin))
+   APPBASE_PLUGIN_REQUIRES(
+      (steem::plugins::chain::chain_plugin)
+      (steem::plugins::p2p::p2p_plugin)
+   )
 
    witness_plugin();
    virtual ~witness_plugin();


### PR DESCRIPTION
This code improves the `block_stats` plugin, and adds stats export from the witness node.  This accomplishes two objectives:

- Get bandwidth / reserve ratio data out of the witness plugin
- Show the "proper" way to use the `block_stats` plugin from another plugin