### PR TITLE
Fix_allow_curation_rewards

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -1525,7 +1525,6 @@ share_type database::pay_curators( const comment_object& c, share_type& max_rewa
 
       if( !c.allow_curation_rewards )
       {
-         unclaimed_rewards = 0;
          max_rewards = 0;
       }
       else if( c.total_vote_weight > 0 )


### PR DESCRIPTION
Normally we have author/curator = 75% / 25%.  When  enable_curation_rewards  is  set to false, the result is  author/curator = 75% / 0%. Thus, 25% of reward_tokens disappears.

When not setting unclaimed_rewards to zero,
the author_tokens are increased by curation_tokens, as  pay_curators( comment, curation_tokens ); returns curation_tokens and not zero.

When applying this PR, the split is changed to author/curator = 100% / 0%, when setting enable_curation_rewards  to false.

