### PR TITLE
Reduce the comment interval from 20 seconds to 3 seconds

### DIFF
--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -605,14 +605,14 @@ void comment_evaluator::do_apply( const comment_operation& o )
          if( o.parent_author == STEEM_ROOT_POST_PARENT )
              FC_ASSERT( ( now - auth.last_root_post ) > STEEM_MIN_ROOT_COMMENT_INTERVAL, "You may only post once every 5 minutes.", ("now",now)("last_root_post", auth.last_root_post) );
          else
-             FC_ASSERT( (now - auth.last_post) > STEEM_MIN_REPLY_INTERVAL, "You may only comment once every 20 seconds.", ("now",now)("auth.last_post",auth.last_post) );
+             FC_ASSERT( (now - auth.last_post) > STEEM_MIN_REPLY_INTERVAL, "You may only comment once every 3 seconds.", ("now",now)("auth.last_post",auth.last_post) );
       }
       else if( _db.has_hardfork( STEEM_HARDFORK_0_6__113 ) )
       {
          if( o.parent_author == STEEM_ROOT_POST_PARENT )
              FC_ASSERT( (now - auth.last_post) > STEEM_MIN_ROOT_COMMENT_INTERVAL, "You may only post once every 5 minutes.", ("now",now)("auth.last_post",auth.last_post) );
          else
-             FC_ASSERT( (now - auth.last_post) > STEEM_MIN_REPLY_INTERVAL, "You may only comment once every 20 seconds.", ("now",now)("auth.last_post",auth.last_post) );
+             FC_ASSERT( (now - auth.last_post) > STEEM_MIN_REPLY_INTERVAL, "You may only comment once every 3 seconds.", ("now",now)("auth.last_post",auth.last_post) );
       }
       else
       {

--- a/libraries/protocol/include/steem/protocol/config.hpp
+++ b/libraries/protocol/include/steem/protocol/config.hpp
@@ -113,7 +113,7 @@
 #define STEEM_VOTE_DUST_THRESHOLD             (50000000)
 
 #define STEEM_MIN_ROOT_COMMENT_INTERVAL       (fc::seconds(60*5)) // 5 minutes
-#define STEEM_MIN_REPLY_INTERVAL              (fc::seconds(20)) // 20 seconds
+#define STEEM_MIN_REPLY_INTERVAL              (fc::seconds(3)) // 3 seconds
 #define STEEM_POST_AVERAGE_WINDOW             (60*60*24u) // 1 day
 #define STEEM_POST_WEIGHT_CONSTANT            (uint64_t(4*STEEM_100_PERCENT) * (4*STEEM_100_PERCENT))// (4*STEEM_100_PERCENT) -> 2 posts per 1 days, average 1 every 12 hours
 


### PR DESCRIPTION
Changed the value of STEEM_MIN_REPLY_INTERVAL to 3.
Adjusted the assert message to match the new value.