### PR TITLE
Constant VESTS to STEEM Conversion rate

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -1994,7 +1994,6 @@ void database::process_funds()
 
       modify( props, [&]( dynamic_global_property_object& p )
       {
-         p.total_vesting_fund_steem += asset( vesting_reward, STEEM_SYMBOL );
          if( !has_hardfork( STEEM_HARDFORK_0_17__774 ) )
             p.total_reward_fund_steem  += asset( content_reward, STEEM_SYMBOL );
          p.current_supply           += asset( new_steem, STEEM_SYMBOL );

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -1990,7 +1990,7 @@ void database::process_funds()
 
       witness_reward /= wso.witness_pay_normalization_factor;
 
-      new_steem = content_reward + vesting_reward + witness_reward;
+      new_steem = content_reward + witness_reward;
 
       modify( props, [&]( dynamic_global_property_object& p )
       {


### PR DESCRIPTION
I have noticed that the conversion rate of STEEM to VESTS has been decreasing over time. I'm not sure why or if it's intentional. While looking at this, I noticed that during the block production, 15% of the inflation goes to a non-existing "vesting fund". The total_vesting_fund_steem gets increased with the 15% but total_vesting_shares remains the same, leading to a change of the conversion rate.

The 15% inflation actually goes nowhere that any user can get but gets counted in virtual supply and current supply, which doesn't seem to make sense.