### PR TITLE
Fix post_apply_transaction typo

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -3331,7 +3331,7 @@ boost::signals2::connection database::add_pre_apply_transaction_handler( const a
 boost::signals2::connection database::add_post_apply_transaction_handler( const apply_transaction_handler_t& func,
    const abstract_plugin& plugin, int32_t group )
 {
-   return connect_impl(_pre_apply_transaction_signal, func, plugin, group, "<-transaction");
+   return connect_impl(_post_apply_transaction_signal, func, plugin, group, "<-transaction");
 }
 
 boost::signals2::connection database::add_pre_apply_block_handler( const apply_block_handler_t& func,


### PR DESCRIPTION
When developing the RC plugin, after some debugging of mysterious non-updated state I finally figured out that `database` connects post-tx handlers are actually connected to the pre-tx signal.

Fortunately, the RC plugin will be the first plugin which attaches to the post-tx signal, so this bug doesn't actually affect anything.