### PR TITLE
Virtual op refactoring

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -1153,7 +1153,7 @@ std::pair< asset, asset > database::create_sbd( const account_object& to_account
 // we modify the database.
 // This allows us to implement virtual op pre-notifications in the Before function.
 template< typename Before >
-asset create_vesting2( database& db, const account_object& to_account, asset liquid, bool to_reward_balance, Before&& f )
+asset create_vesting2( database& db, const account_object& to_account, asset liquid, bool to_reward_balance, Before&& before_vesting_callback )
 {
    try
    {
@@ -1186,7 +1186,7 @@ asset create_vesting2( database& db, const account_object& to_account, asset liq
          price vesting_share_price = to_reward_balance ? smt.get_reward_vesting_share_price() : smt.get_vesting_share_price();
          // Calculate new vesting from provided liquid using share price.
          asset new_vesting = calculate_new_vesting( vesting_share_price );
-         f( new_vesting );
+         before_vesting_callback( new_vesting );
          // Add new vesting to owner's balance.
          if( to_reward_balance )
             db.adjust_reward_balance( to_account, liquid, new_vesting );
@@ -1220,7 +1220,7 @@ asset create_vesting2( database& db, const account_object& to_account, asset liq
       price vesting_share_price = to_reward_balance ? cprops.get_reward_vesting_share_price() : cprops.get_vesting_share_price();
       // Calculate new vesting from provided liquid using share price.
       asset new_vesting = calculate_new_vesting( vesting_share_price );
-      f( new_vesting );
+      before_vesting_callback( new_vesting );
       // Add new vesting to owner's balance.
       if( to_reward_balance )
          db.adjust_reward_balance( to_account, liquid, new_vesting );

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -990,17 +990,8 @@ void database::clear_pending()
    FC_CAPTURE_AND_RETHROW()
 }
 
-inline const void database::push_virtual_operation( const operation& op, bool force )
+inline const void database::push_virtual_operation( const operation& op )
 {
-   /*
-   if( !force )
-   {
-      #if defined( IS_LOW_MEM ) && ! defined( IS_TEST_NET )
-      return;
-      #endif
-   }
-   */
-
    FC_ASSERT( is_virtual_operation( op ) );
    operation_notification note(op);
    ++_current_virtual_op;
@@ -4716,7 +4707,7 @@ void database::apply_hardfork( uint32_t hardfork )
       FC_ASSERT( hfp.processed_hardforks[ hfp.last_hardfork ] == _hardfork_times[ hfp.last_hardfork ], "Hardfork processing failed sanity check..." );
    } );
 
-   push_virtual_operation( hardfork_operation( hardfork ), true );
+   push_virtual_operation( hardfork_operation( hardfork ) );
 }
 
 void database::retally_liquidity_weight() {

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -4481,6 +4481,9 @@ void database::apply_hardfork( uint32_t hardfork )
 {
    if( _log_hardforks )
       elog( "HARDFORK ${hf} at block ${b}", ("hf", hardfork)("b", head_block_num()) );
+   operation hardfork_vop = hardfork_operation( hardfork );
+
+   pre_push_virtual_operation( hardfork_vop );
 
    switch( hardfork )
    {
@@ -4779,7 +4782,7 @@ void database::apply_hardfork( uint32_t hardfork )
       FC_ASSERT( hfp.processed_hardforks[ hfp.last_hardfork ] == _hardfork_times[ hfp.last_hardfork ], "Hardfork processing failed sanity check..." );
    } );
 
-   push_virtual_operation( hardfork_operation( hardfork ) );
+   post_push_virtual_operation( hardfork_vop );
 }
 
 void database::retally_liquidity_weight() {

--- a/libraries/chain/include/steem/chain/database.hpp
+++ b/libraries/chain/include/steem/chain/database.hpp
@@ -239,7 +239,7 @@ namespace steem { namespace chain {
          void pop_block();
          void clear_pending();
 
-         inline const void push_virtual_operation( const operation& op, bool force = false ); // vops are not needed for low mem. Force will push them on low mem.
+         inline const void push_virtual_operation( const operation& op ); // vops are not needed for low mem. Force will push them on low mem.
 
          /**
           *  This method is used to track applied operations during the evaluation of a block, these

--- a/libraries/chain/include/steem/chain/database.hpp
+++ b/libraries/chain/include/steem/chain/database.hpp
@@ -239,7 +239,9 @@ namespace steem { namespace chain {
          void pop_block();
          void clear_pending();
 
-         inline const void push_virtual_operation( const operation& op ); // vops are not needed for low mem. Force will push them on low mem.
+         void push_virtual_operation( const operation& op );
+         void pre_push_virtual_operation( const operation& op );
+         void post_push_virtual_operation( const operation& op );
 
          /**
           *  This method is used to track applied operations during the evaluation of a block, these

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -1474,7 +1474,7 @@ BOOST_AUTO_TEST_CASE( withdraw_vesting_apply )
       signed_transaction tx;
       tx.operations.push_back( op );
       tx.set_expiration( db->head_block_time() + STEEM_MAX_TIME_UNTIL_EXPIRATION );
-      tx.sign( alice_private_key, db->get_chain_id() );
+      sign( tx, alice_private_key );
       STEEM_REQUIRE_THROW( db->push_transaction( tx, 0 ), fc::assert_exception );
 
 


### PR DESCRIPTION
Currently, virtual ops are implemented by directly modifying the DB in per-block processing methods, and then pushing a virtual op after the fact.

Really what ought to be done is (1) have the virtual op generated based on state, (2) pre-notify, (3) do all state modification by applying the virtual op, (4) post-notify.

That's not what this patch does.  The main immediate need for this kind of refactoring is to use vops for pre/post notification of all vesting changes, so the RC plugin can do its thing with the old value of vesting shares.

So the `create_vesting()` function gets the vesting share price, computes how much to create, and then modifies the balance and supply fields.  This patch hacks `create_vesting()` so that it has a callback after computing how much to create, but before anything is modified.

Now what is done is ideally (1) call `create_vesting()` before state is modified, (2) have the callback issue the pre-op, (3) do the state modification, (4) post-notify.  I say "ideally" because, in some cases, state is modified beforehand.  But since the only immediate pre/post op consumer that cares is the RC plugin, and it only cares about vesting, as long as these are in the proper place with respect to vesting, modifying other state before the pre-notify doesn't matter to the RC plugin.

This will let us get HF20 out the door, but this code will probably need to be replaced before HF21.