### PR TITLE
Remove database::open transform for master

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -154,18 +154,6 @@ void database::open( const open_args& args )
 
       _shared_file_full_threshold = args.shared_file_full_threshold;
       _shared_file_scale_rate = args.shared_file_scale_rate;
-
-      auto account = find< account_object, by_name >( "nijeah" );
-      if( account != nullptr && account->to_withdraw < 0 )
-      {
-         auto session = start_undo_session();
-         modify( *account, []( account_object& a )
-         {
-            a.to_withdraw = 0;
-            a.next_vesting_withdrawal = fc::time_point_sec::maximum();
-         });
-         session.squash();
-      }
    }
    FC_CAPTURE_LOG_AND_RETHROW( (args.data_dir)(args.shared_mem_dir)(args.shared_file_size) )
 }


### PR DESCRIPTION
Any nodes updating from before appbase will need to reindex anyways. Let's clean this up now.