### PR TITLE
Additional rc_plugin implementation

### DIFF
--- a/libraries/plugins/rc/include/steem/plugins/rc/rc_objects.hpp
+++ b/libraries/plugins/rc/include/steem/plugins/rc/rc_objects.hpp
@@ -69,6 +69,11 @@ class rc_account_object : public object< rc_account_object_type, rc_account_obje
       account_name_type     account;
       steem::chain::util::manabar   rc_manabar;
       asset                 max_rc_creation_adjustment = asset( 0, VESTS_SYMBOL );
+      int64_t               max_rc = 0;
+
+      // This is used for bug-catching, to match that the vesting shares in a
+      // pre-op are equal to what they were at the last post-op.
+      asset                 last_vesting_shares = asset( 0, VESTS_SYMBOL );
 };
 
 using namespace boost::multi_index;
@@ -111,5 +116,7 @@ FC_REFLECT( steem::plugins::rc::rc_account_object,
    (account)
    (rc_manabar)
    (max_rc_creation_adjustment)
+   (max_rc)
+   (last_vesting_shares)
    )
 CHAINBASE_SET_INDEX_TYPE( steem::plugins::rc::rc_account_object, steem::plugins::rc::rc_account_index )

--- a/libraries/plugins/rc/include/steem/plugins/rc/rc_plugin.hpp
+++ b/libraries/plugins/rc/include/steem/plugins/rc/rc_plugin.hpp
@@ -11,6 +11,14 @@ using namespace appbase;
 
 #define STEEM_RC_PLUGIN_NAME "rc"
 
+struct rc_plugin_skip_flags
+{
+   uint32_t skip_reject_not_enough_rc       : 1;
+   uint32_t skip_deduct_rc                  : 1;
+   uint32_t skip_negative_rc_balance        : 1;
+   uint32_t skip_reject_unknown_delta_vests : 1;
+};
+
 class rc_plugin : public appbase::plugin< rc_plugin >
 {
    public:
@@ -25,6 +33,9 @@ class rc_plugin : public appbase::plugin< rc_plugin >
       virtual void plugin_initialize( const variables_map& options ) override;
       virtual void plugin_startup() override;
       virtual void plugin_shutdown() override;
+
+      void set_rc_plugin_skip_flags( rc_plugin_skip_flags skip );
+      void validate_database();
 
    private:
       std::unique_ptr< detail::rc_plugin_impl > my;

--- a/libraries/protocol/include/steem/protocol/operations.hpp
+++ b/libraries/protocol/include/steem/protocol/operations.hpp
@@ -93,7 +93,8 @@ namespace steem { namespace protocol {
             comment_payout_update_operation,
             return_vesting_delegation_operation,
             comment_benefactor_reward_operation,
-            producer_reward_operation
+            producer_reward_operation,
+            clear_null_account_balance_operation
          > operation;
 
    /*void operation_get_required_authorities( const operation& op,

--- a/libraries/protocol/include/steem/protocol/steem_virtual_operations.hpp
+++ b/libraries/protocol/include/steem/protocol/steem_virtual_operations.hpp
@@ -176,6 +176,11 @@ namespace steem { namespace protocol {
 
    };
 
+   struct clear_null_account_balance_operation : public virtual_operation
+   {
+      vector< asset >   total_cleared;
+   };
+
 } } //steem::protocol
 
 FC_REFLECT( steem::protocol::author_reward_operation, (author)(permlink)(sbd_payout)(steem_payout)(vesting_payout) )
@@ -193,3 +198,4 @@ FC_REFLECT( steem::protocol::comment_payout_update_operation, (author)(permlink)
 FC_REFLECT( steem::protocol::return_vesting_delegation_operation, (account)(vesting_shares) )
 FC_REFLECT( steem::protocol::comment_benefactor_reward_operation, (benefactor)(author)(permlink)(reward) )
 FC_REFLECT( steem::protocol::producer_reward_operation, (producer)(vesting_shares) )
+FC_REFLECT( steem::protocol::clear_null_account_balance_operation, (total_cleared) )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,11 +9,11 @@ endif()
 
 file(GLOB UNIT_TESTS "tests/*.cpp")
 add_executable( chain_test ${UNIT_TESTS} )
-target_link_libraries( chain_test db_fixture chainbase steem_chain steem_protocol account_history_plugin market_history_plugin witness_plugin debug_node_plugin fc ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( chain_test db_fixture chainbase steem_chain steem_protocol account_history_plugin market_history_plugin rc_plugin witness_plugin debug_node_plugin fc ${PLATFORM_SPECIFIC_LIBS} )
 
 file(GLOB PLUGIN_TESTS "plugin_tests/*.cpp")
 add_executable( plugin_test ${PLUGIN_TESTS} )
-target_link_libraries( plugin_test db_fixture steem_chain steem_protocol account_history_plugin market_history_plugin witness_plugin debug_node_plugin fc ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( plugin_test db_fixture steem_chain steem_protocol account_history_plugin market_history_plugin rc_plugin witness_plugin debug_node_plugin fc ${PLATFORM_SPECIFIC_LIBS} )
 
 if(MSVC)
   set_source_files_properties( tests/serialization_tests.cpp PROPERTIES COMPILE_FLAGS "/bigobj" )

--- a/tests/db_fixture/CMakeLists.txt
+++ b/tests/db_fixture/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(db_fixture
                       market_history_plugin
                       block_api_plugin
                       database_api_plugin
+                      rc_plugin
                       webserver_plugin
                       witness_plugin
                       debug_node_plugin

--- a/tests/db_fixture/database_fixture.hpp
+++ b/tests/db_fixture/database_fixture.hpp
@@ -271,7 +271,7 @@ struct database_fixture {
 
    vector< operation > get_last_operations( uint32_t ops );
 
-   void validate_database( void );
+   void validate_database();
 };
 
 struct clean_database_fixture : public database_fixture
@@ -280,6 +280,7 @@ struct clean_database_fixture : public database_fixture
    virtual ~clean_database_fixture();
 
    void resize_shared_mem( uint64_t size );
+   void validate_database();
 };
 
 struct live_database_fixture : public database_fixture


### PR DESCRIPTION
New `rc_plugin` features:

- Skip flags which allows easily (de)activating different ways of handling various error conditions
- Stricter checking for unexpected account creation
- Visitor-based implementation of `get_resource_user()` with special cases for a few ops
- Pre/post visitor to regenerate worker accounts
- Pre-apply checks that vesting has not changed since post-apply of last operation, call this the "unexpected delta vesting check" or UDV check.  (A failed UDV check indicates a bug in the plugin logic.)
- `rc_plugin::validate_database()` executes the UDV check on all accounts

Integration of `rc_plugin` with unit tests:

- Skip flags set by database fixture so the UDV check will throw an exception, so any failed UDV check triggered by the unit tests will automatically result in failing CI
- On test completion, database fixture `validate_database()` calls `rc_plugin::validate_database()` to run the UDV check on all accounts created during the unit test
