### PR TITLE
2140 fix boost test loop pointers

### DIFF
--- a/tests/tests/operation_time_tests.cpp
+++ b/tests/tests/operation_time_tests.cpp
@@ -2800,6 +2800,7 @@ BOOST_AUTO_TEST_CASE( sbd_stability )
       // Keep producing blocks until printing SBD is back
       while( ( gpo.current_sbd_supply * exchange_rate ).amount >= ( gpo.virtual_supply.amount * gpo.sbd_start_percent ) / STEEM_100_PERCENT )
       {
+         auto& gpo = db->get_dynamic_global_properties();
          BOOST_REQUIRE( gpo.sbd_print_rate >= last_print_rate );
          last_print_rate = gpo.sbd_print_rate;
          db_plugin->debug_generate_blocks( debug_key, 1, database::skip_witness_signature );

--- a/tests/tests/operation_time_tests.cpp
+++ b/tests/tests/operation_time_tests.cpp
@@ -2798,7 +2798,7 @@ BOOST_AUTO_TEST_CASE( sbd_stability )
       auto last_print_rate = db->get_dynamic_global_properties().sbd_print_rate;
 
       // Keep producing blocks until printing SBD is back
-      while( ( gpo.current_sbd_supply * exchange_rate ).amount >= ( gpo.virtual_supply.amount * gpo.sbd_start_percent ) / STEEM_100_PERCENT )
+      while( ( db->get_dynamic_global_properties().current_sbd_supply * exchange_rate ).amount >= ( db->get_dynamic_global_properties().virtual_supply.amount * db->get_dynamic_global_properties().sbd_start_percent ) / STEEM_100_PERCENT )
       {
          auto& gpo = db->get_dynamic_global_properties();
          BOOST_REQUIRE( gpo.sbd_print_rate >= last_print_rate );


### PR DESCRIPTION
This PR changes the `gpo.` references back to `db->get_dynamic_global_properties()` and adds back the `gpo` lookup inside the loop, since based on @theoreticalbts's comment in the main PR - the pointers may become invalid when blocks are produced inside the loop.