### PR TITLE
Split build in two for CI on develop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM phusion/baseimage:0.9.19
 
 ARG STEEM_STATIC_BUILD=ON
 ENV STEEM_STATIC_BUILD ${STEEM_STATIC_BUILD}
+ARG BUILD_STEP
+ENV BUILD_STEP ${BUILD_STEP}
 
 ENV LANG=en_US.UTF-8
 
@@ -51,6 +53,7 @@ RUN \
 ADD . /usr/local/src/steem
 
 RUN \
+    if [ "$BUILD_STEP" = "1" ] || [ ! "$BUILD_STEP" ] ; then \
     cd /usr/local/src/steem && \
     git submodule update --init --recursive && \
     mkdir build && \
@@ -71,9 +74,11 @@ RUN \
     PYTHONPATH=programs/build_helpers \
     python3 -m steem_build_helpers.check_reflect && \
     programs/build_helpers/get_config_check.sh && \
-    rm -rf /usr/local/src/steem/build
+    rm -rf /usr/local/src/steem/build ; \
+    fi
 
 RUN \
+    if [ "$BUILD_STEP" = "2" ] || [ ! "$BUILD_STEP" ] ; then \
     cd /usr/local/src/steem && \
     git submodule update --init --recursive && \
     mkdir build && \
@@ -98,9 +103,11 @@ RUN \
     PYTHONPATH=programs/build_helpers \
     python3 -m steem_build_helpers.check_reflect && \
     programs/build_helpers/get_config_check.sh && \
-    rm -rf /usr/local/src/steem/build
+    rm -rf /usr/local/src/steem/build ; \
+    fi
 
 RUN \
+    if [ "$BUILD_STEP" = "1" ] || [ ! "$BUILD_STEP" ] ; then \
     cd /usr/local/src/steem && \
     git submodule update --init --recursive && \
     mkdir build && \
@@ -120,9 +127,11 @@ RUN \
     mkdir -p /var/cobertura && \
     gcovr --object-directory="../" --root=../ --xml-pretty --gcov-exclude=".*tests.*" --gcov-exclude=".*fc.*" --gcov-exclude=".*app*" --gcov-exclude=".*net*" --gcov-exclude=".*plugins*" --gcov-exclude=".*schema*" --gcov-exclude=".*time*" --gcov-exclude=".*utilities*" --gcov-exclude=".*wallet*" --gcov-exclude=".*programs*" --output="/var/cobertura/coverage.xml" && \
     cd /usr/local/src/steem && \
-    rm -rf /usr/local/src/steem/build
+    rm -rf /usr/local/src/steem/build ; \
+    fi
 
 RUN \
+    if [ "$BUILD_STEP" = "2" ] || [ ! "$BUILD_STEP" ] ; then \
     cd /usr/local/src/steem && \
     git submodule update --init --recursive && \
     mkdir build && \
@@ -162,7 +171,8 @@ RUN \
     && \
     make -j$(nproc) && \
     make install && \
-    rm -rf /usr/local/src/steem
+    rm -rf /usr/local/src/steem ; \
+    fi
 
 RUN \
     apt-get remove -y \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,14 @@ pipeline {
   stages {
     stage('Build') {
       steps {
-        sh 'ciscripts/triggerbuild.sh'
+        parallel ( "Build tests":
+        {
+          sh 'ciscripts/triggertests.sh'
+          step([$class: 'CoberturaPublisher', autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '**/cobertura/coverage.xml', failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false])
+        },
+        "Build docker image": {
+          sh 'ciscripts/triggerbuild.sh'
+        })
       }
     }
   }

--- a/ciscripts/buildscript.sh
+++ b/ciscripts/buildscript.sh
@@ -4,8 +4,6 @@ export IMAGE_NAME="steemit/steem:$BRANCH_NAME"
 if [[ $IMAGE_NAME == "steemit/steem:stable" ]] ; then
   IMAGE_NAME="steemit/steem:latest"
 fi
-sudo docker build -t=$IMAGE_NAME .
+sudo docker build --build-arg BUILD_STEP=2 -t=$IMAGE_NAME .
 sudo docker login --username=$DOCKER_USER --password=$DOCKER_PASS
 sudo docker push $IMAGE_NAME
-sudo docker run -v /var/jenkins_home:/var/jenkins $IMAGE_NAME cp -r /var/cobertura /var/jenkins
-cp -r /var/jenkins_home/cobertura .

--- a/ciscripts/buildtests.sh
+++ b/ciscripts/buildtests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+sudo docker build --build-arg BUILD_STEP=1 -t=steemit/steem:tests .
+sudo docker run -v $WORKSPACE:/var/jenkins steemit/steem:tests cp -r /var/cobertura /var/jenkins

--- a/ciscripts/triggertests.sh
+++ b/ciscripts/triggertests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+if /bin/bash $WORKSPACE/ciscripts/buildtests.sh; then
+  echo BUILD SUCCESS
+else
+  echo BUILD FAILURE
+  exit 1
+fi


### PR DESCRIPTION
Two different parallel jobs are called as part of the build process - they are split using build args to the docker build command, which is defined in the existing single Dockerfile.

If no build args are specified, everything will build in sequence as usual, so it does not break existing functionality of docker build .

This also fixes cobertura code coverage which is viewable in jenkins.