### PR TITLE
Implement missing FC typenames

### DIFF
--- a/libraries/fc/include/fc/reflect/typename.hpp
+++ b/libraries/fc/include/fc/reflect/typename.hpp
@@ -2,6 +2,7 @@
 
 #include <deque>
 #include <map>
+#include <set>
 #include <vector>
 
 #include <fc/string.hpp>
@@ -67,6 +68,15 @@ namespace fc {
      static const char* name()  {
          static std::string n = std::string("std::map<") + get_typename<K>::name() + ","+get_typename<V>::name()+">";
          return n.c_str();
+     }
+  };
+
+  template<typename E> struct get_typename< std::set<E> >
+  {
+     static const char* name()
+     {
+        static std::string n = std::string("std::set<") + std::string(get_typename<E>::name()) + std::string(">");
+        return n.c_str();
      }
   };
 

--- a/libraries/fc/include/fc/reflect/typename.hpp
+++ b/libraries/fc/include/fc/reflect/typename.hpp
@@ -70,6 +70,15 @@ namespace fc {
      }
   };
 
+  template<typename A, typename B> struct get_typename< std::pair<A,B> >
+  {
+      static const char* name()
+      {
+         static std::string n = std::string("std::pair<") + get_typename<A>::name() + "," + get_typename<B>::name() + ">";
+         return n.c_str();
+      }
+  };
+
   struct signed_int;
   struct unsigned_int;
   template<> struct get_typename<signed_int>   { static const char* name()   { return "signed_int";   } };

--- a/libraries/fc/include/fc/static_variant.hpp
+++ b/libraries/fc/include/fc/static_variant.hpp
@@ -424,5 +424,46 @@ struct visitor {
       s.visit( fc::to_static_variant( v_object[ "value" ] ) );
    }
 
-   template<typename... T> struct get_typename { static const char* name()   { return typeid(static_variant<T...>).name();   } };
+   template< typename... T > struct get_comma_separated_typenames;
+
+   template<>
+   struct get_comma_separated_typenames<>
+   {
+      static const char* names() { return ""; }
+   };
+
+   template< typename T >
+   struct get_comma_separated_typenames<T>
+   {
+      static const char* names()
+      {
+         static const std::string n = get_typename<T>::name();
+         return n.c_str();
+      }
+   };
+
+   template< typename T, typename... Ts >
+   struct get_comma_separated_typenames<T, Ts...>
+   {
+      static const char* names()
+      {
+         static const std::string n =
+            std::string( get_typename<T>::name() )+","+
+            std::string( get_comma_separated_typenames< Ts... >::names() );
+         return n.c_str();
+      }
+   };
+
+   template< typename... T >
+   struct get_typename< static_variant< T... > >
+   {
+      static const char* name()
+      {
+         static const std::string n = std::string( "fc::static_variant<" )
+            + get_comma_separated_typenames<T...>::names()
+            + ">";
+         return n.c_str();
+      }
+   };
+
 } // namespace fc


### PR DESCRIPTION
`fc::static_variant` had a broken implementation of `fc::get_typename` which accidentally defined `fc::typename` for every class.  I fixed it, and implemented two missing `fc::get_typename` definitions, whose absence now properly causes compilation errors after fixing `static_variant`.
