### PR TITLE
Object dumping code for #2549

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -5333,4 +5333,7 @@ vector< asset_symbol_type > database::get_smt_next_identifier()
 }
 #endif
 
+index_info::index_info() {}
+index_info::~index_info() {}
+
 } } //steem::chain

--- a/libraries/chain/include/steem/chain/index.hpp
+++ b/libraries/chain/include/steem/chain/index.hpp
@@ -1,13 +1,46 @@
 #pragma once
 
+#include <steem/schema/schema.hpp>
+#include <steem/protocol/schema_types.hpp>
+#include <steem/chain/schema_types.hpp>
+
 #include <steem/chain/database.hpp>
 
 namespace steem { namespace chain {
+
+using steem::schema::abstract_schema;
+
+struct index_info
+   : public chainbase::index_extension
+{
+   index_info();
+   virtual ~index_info();
+   virtual std::shared_ptr< abstract_schema > get_schema() = 0;
+};
+
+template< typename MultiIndexType >
+struct index_info_impl
+   : public index_info
+{
+   typedef typename MultiIndexType::value_type value_type;
+
+   index_info_impl()
+      : _schema( steem::schema::get_schema_for_type< value_type >() ) {}
+   virtual ~index_info_impl() {}
+
+   virtual std::shared_ptr< abstract_schema > get_schema() override
+   {   return _schema;   }
+
+   std::shared_ptr< abstract_schema > _schema;
+};
 
 template< typename MultiIndexType >
 void _add_index_impl( database& db )
 {
    db.add_index< MultiIndexType >();
+   std::shared_ptr< chainbase::index_extension > ext =
+      std::make_shared< index_info_impl< MultiIndexType > >();
+   db.add_index_extension< MultiIndexType >( ext );
 }
 
 template< typename MultiIndexType >

--- a/libraries/protocol/include/steem/protocol/schema_types.hpp
+++ b/libraries/protocol/include/steem/protocol/schema_types.hpp
@@ -2,3 +2,4 @@
 
 #include <steem/protocol/schema_types/account_name_type.hpp>
 #include <steem/protocol/schema_types/asset_symbol_type.hpp>
+#include <steem/protocol/schema_types/fixed_string.hpp>

--- a/libraries/protocol/include/steem/protocol/schema_types/fixed_string.hpp
+++ b/libraries/protocol/include/steem/protocol/schema_types/fixed_string.hpp
@@ -12,21 +12,21 @@ namespace steem { namespace schema { namespace detail {
 // fixed_string                             //
 //////////////////////////////////////////////
 
-template<typename Storage>
+template< size_t N >
 struct schema_fixed_string_impl
    : public abstract_schema
 {
    STEEM_SCHEMA_TEMPLATE_CLASS_BODY( schema_fixed_string_impl )
 };
 
-template<typename Storage>
-void schema_fixed_string_impl<Storage>::get_deps( std::vector< std::shared_ptr< abstract_schema > >& deps )
+template< size_t N >
+void schema_fixed_string_impl<N>::get_deps( std::vector< std::shared_ptr< abstract_schema > >& deps )
 {
    return;
 }
 
-template<typename Storage>
-void schema_fixed_string_impl<Storage>::get_str_schema( std::string& s )
+template< size_t N >
+void schema_fixed_string_impl<N>::get_str_schema( std::string& s )
 {
    if( str_schema != "" )
    {
@@ -38,7 +38,9 @@ void schema_fixed_string_impl<Storage>::get_str_schema( std::string& s )
    get_name( my_name );
    fc::mutable_variant_object mvo;
    mvo("name", my_name)
-      ("type", "prim");
+      ("type", "string")
+      ("max_size", N)
+      ;
 
    str_schema = fc::json::to_string( mvo );
    s = str_schema;
@@ -47,10 +49,10 @@ void schema_fixed_string_impl<Storage>::get_str_schema( std::string& s )
 
 }
 
-template<typename Storage>
-struct schema_reflect< typename fc::fixed_string<Storage> >
+template< size_t N >
+struct schema_reflect< typename steem::protocol::fixed_string_impl_for_size<N> >
 {
-   typedef detail::schema_fixed_string_impl< Storage >        schema_impl_type;
+   typedef detail::schema_fixed_string_impl< N >        schema_impl_type;
 };
 
 } }

--- a/libraries/schema/include/steem/schema/schema_types.hpp
+++ b/libraries/schema/include/steem/schema/schema_types.hpp
@@ -1,7 +1,6 @@
 
 #pragma once
 
-#include <steem/schema/schema_types/fixed_string.hpp>
 #include <steem/schema/schema_types/flat_map.hpp>
 #include <steem/schema/schema_types/flat_set.hpp>
 #include <steem/schema/schema_types/static_variant.hpp>

--- a/programs/util/CMakeLists.txt
+++ b/programs/util/CMakeLists.txt
@@ -55,6 +55,17 @@ install( TARGETS
    ARCHIVE DESTINATION lib
 )
 
+add_executable( dump_steem_schema dump_steem_schema.cpp )
+target_link_libraries( dump_steem_schema
+                       PRIVATE steem_chain steem_protocol fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+install( TARGETS
+   dump_steem_schema
+
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib
+)
+
 add_executable( schema_test schema_test.cpp )
 target_link_libraries( schema_test
                        PRIVATE steem_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )

--- a/programs/util/dump_steem_schema.cpp
+++ b/programs/util/dump_steem_schema.cpp
@@ -1,0 +1,107 @@
+#include <steem/protocol/types_fwd.hpp>
+
+#include <steem/schema/schema.hpp>
+#include <steem/schema/schema_impl.hpp>
+#include <steem/schema/schema_types.hpp>
+
+#include <steem/chain/schema_types/oid.hpp>
+#include <steem/protocol/schema_types/account_name_type.hpp>
+#include <steem/protocol/schema_types/asset_symbol_type.hpp>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <steem/chain/account_object.hpp>
+#include <steem/chain/steem_objects.hpp>
+#include <steem/chain/database.hpp>
+#include <steem/chain/index.hpp>
+
+using steem::schema::abstract_schema;
+
+struct schema_info
+{
+   schema_info( std::shared_ptr< abstract_schema > s )
+   {
+      std::vector< std::shared_ptr< abstract_schema > > dep_schemas;
+      s->get_deps( dep_schemas );
+      for( const std::shared_ptr< abstract_schema >& ds : dep_schemas )
+      {
+         deps.emplace_back();
+         ds->get_name( deps.back() );
+      }
+      std::string str_schema;
+      s->get_str_schema( str_schema );
+      schema = fc::json::from_string( str_schema );
+   }
+
+   std::vector< std::string >   deps;
+   fc::variant                  schema;
+};
+
+void add_to_schema_map(
+   std::map< std::string, schema_info >& m,
+   std::shared_ptr< abstract_schema > schema,
+   bool follow_deps = true )
+{
+   std::string name;
+   schema->get_name( name );
+
+   if( m.find( name ) != m.end() )
+      return;
+   // TODO:  Use iterative, not recursive, algorithm
+   m.emplace( name, schema );
+
+   if( !follow_deps )
+      return;
+
+   std::vector< std::shared_ptr< abstract_schema > > dep_schemas;
+   schema->get_deps( dep_schemas );
+   for( const std::shared_ptr< abstract_schema >& ds : dep_schemas )
+      add_to_schema_map( m, ds, follow_deps );
+}
+
+struct steem_schema
+{
+   std::map< std::string, schema_info >     schema_map;
+   std::vector< std::string >               chain_object_types;
+};
+
+FC_REFLECT( schema_info, (deps)(schema) )
+FC_REFLECT( steem_schema, (schema_map)(chain_object_types) )
+
+int main( int argc, char** argv, char** envp )
+{
+   steem::chain::database db;
+   steem::chain::database::open_args db_args;
+
+   db_args.data_dir = "tempdata";
+   db_args.shared_mem_dir = "tempdata/blockchain";
+   db_args.shared_file_size = 1024*1024*8;
+
+   std::map< std::string, schema_info > schema_map;
+
+   db.open( db_args );
+
+   steem_schema ss;
+
+   std::vector< std::string > chain_objects;
+   db.for_each_index_extension< steem::chain::index_info >(
+      [&]( std::shared_ptr< steem::chain::index_info > info )
+      {
+         std::string name;
+         info->get_schema()->get_name( name );
+         // std::cout << name << std::endl;
+
+         add_to_schema_map( ss.schema_map, info->get_schema() );
+         ss.chain_object_types.push_back( name );
+      } );
+
+   std::cout << fc::json::to_string( ss ) << std::endl;
+
+   db.close();
+
+   return 0;
+}

--- a/programs/util/object_size.py
+++ b/programs/util/object_size.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import json
+
+builtin_type_sizes = {
+   "int8_t" : 1,
+   "int16_t" : 2,
+   "int32_t" : 4,
+   "int64_t" : 8,
+   "uint8_t" : 1,
+   "uint16_t" : 2,
+   "uint32_t" : 4,
+   "uint64_t" : 8,
+
+   "char" : 1,
+   "bool" : 1,
+
+   "fc::time_point_sec" : 4,
+   "steem::protocol::asset_symbol_type" : 8,
+   "steem::protocol::account_name_type" : 16,
+}
+
+class TermSum(object):
+    def __init__(self):
+        self.term_to_count = {}
+
+    def __add__(self, rhs):
+        if rhs == 0:
+            return self
+        if isinstance(rhs, int):
+            self.term_to_count[""] += rhs
+            return
+        if not isinstance(rhs, TermSum):
+            raise NotImplemented
+        result = TermSum()
+        result.term_to_count = dict(self.term_to_count)
+        for term, count in rhs.term_to_count.items():
+            result.term_to_count[term] = result.term_to_count.get(term, 0)+count
+        return result
+
+    def __radd__(self, lhs):
+        return self.__add__(lhs)
+
+    def __str__(self):
+        return "+".join( "{} {}".format( count, term ) for term, count in sorted(self.term_to_count.items()) )
+
+def term(count, name):
+    ts = TermSum()
+    ts.term_to_count = {name : count}
+    return ts
+
+class Sizer(object):
+    def __init__(self, schema_map=None):
+        self.type_to_size = {}
+        self.schema_map = schema_map
+
+    def get_size(self, name):
+        y = self.type_to_size.get(name)
+        if y is not None:
+            return y
+        y = self._compute_size( name )
+        self.type_to_size[name] = y
+        return y
+
+    def _compute_size( self, name ):
+        y = builtin_type_sizes.get(name)
+        if y is not None:
+            return term(y, "bytes")
+
+        s = self.schema_map[name]
+        deps = s["deps"]
+        schema = s["schema"]
+        t = schema["type"]
+
+        if t == "oid":
+            return term(8, "bytes")
+        if t == "class":
+            return sum( self.get_size(mtype) for mtype, mname in schema["members"] )
+        return term(1, name)
+
+def main():
+    with open("steem.schema", "r") as f:
+        schema = json.load(f)
+
+    schema_map = schema["schema_map"]
+    chain_object_types = schema["chain_object_types"]
+    sizer = Sizer(schema_map=schema_map)
+    for t in chain_object_types:
+        s = sizer.get_size(t)
+        print(t)
+        print("    "+str(s))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
PR #2702 has a number of hard-coded size constants.  This PR contains the code I used to get the values of these constants.  Run `dump_steem_schema`, send the output to a file called `steem.schema`, then run `object_size.py`, as of current `develop` the output is this:

```
steem::chain::dynamic_global_property_object
    301 bytes+1 uint160_t
steem::chain::account_object   
    415 bytes+1 fc::array<char,33>+1 fc::array<steem::protocol::share_type,4>+1 steem::chain::shared_string
steem::chain::account_authority_object
    3 bip::flat_map<steem::protocol::public_key_type,uint16_t>+40 bytes+3 steem::chain::shared_authority::account_authority_map
steem::chain::witness_object
    198 bytes+1 fc::array<char,33>+1 fc::sha256+1 steem::chain::shared_string+1 steem::chain::witness_object::witness_schedule_type
steem::chain::transaction_object
    12 bytes+1 steem::chain::buffer_type+1 uint160_t
steem::chain::block_summary_object
    8 bytes+1 uint160_t
steem::chain::witness_schedule_object
    86 bytes+1 fc::array<steem::protocol::account_name_type,21>
steem::chain::comment_object   
    1 bip::vector<std::pair<steem::protocol::asset_symbol_type,fc::static_variant<steem::protocol::votable_asset_info_v1>>>+1 bip::vector<steem::protocol::beneficiary_route_type>+201 bytes+3 steem::chain::shared_string
steem::chain::comment_content_object
    16 bytes+3 steem::chain::shared_string
steem::chain::comment_vote_object
    47 bytes
steem::chain::witness_vote_object
    40 bytes
steem::chain::limit_order_object
    76 bytes
steem::chain::feed_history_object
    1 bip::deque<steem::protocol::price>+40 bytes
steem::chain::convert_request_object
    48 bytes
steem::chain::liquidity_reward_balance_object
    52 bytes
steem::chain::operation_object 
    28 bytes+1 steem::chain::buffer_type+1 uint160_t
steem::chain::account_history_object
    36 bytes
steem::chain::hardfork_property_object
    1 bip::vector<fc::time_point_sec>+24 bytes
steem::chain::withdraw_vesting_route_object
    43 bytes
steem::chain::owner_authority_history_object
    1 bip::flat_map<steem::protocol::public_key_type,uint16_t>+32 bytes+1 steem::chain::shared_authority::account_authority_map
steem::chain::account_recovery_request_object
    1 bip::flat_map<steem::protocol::public_key_type,uint16_t>+32 bytes+1 steem::chain::shared_authority::account_authority_map
steem::chain::change_recovery_account_request_object
    44 bytes
steem::chain::escrow_object
    119 bytes
steem::chain::savings_withdraw_object
    64 bytes+1 steem::chain::shared_string
steem::chain::decline_voting_rights_request_object
    28 bytes
steem::chain::reward_fund_object
    80 bytes+2 steem::protocol::curve_id
steem::chain::vesting_delegation_object
    60 bytes
steem::chain::vesting_delegation_expiration_object
    44 bytes
steem::chain::smt_token_object 
    253 bytes+2 fc::sha256+1 flat_set<steem::protocol::future_extensions>+1 steem::chain::smt_phase+5 steem::protocol::authority::account_authority_map
steem::chain::smt_event_token_object
    32 bytes+1 steem::chain::smt_phase
steem::chain::account_regular_balance_object
    56 bytes
steem::chain::account_rewards_balance_object
    72 bytes
```

I manually compared this auto-generated information with the content of the objects and the evaluator code for each operation, to inform the implementation and constants of `resource_count.cpp` in the PR #2702.

I implemented the constants as hard-coded values with the purposeful intent that changes to the state size heuristic should be gated through code review.