### PR TITLE
Fail entire build fast when one part of the job fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         },
         "Build docker image": {
           sh 'ciscripts/triggerbuild.sh'
-        })
+        }, failFast: true )
       }
     }
   }

--- a/ciscripts/buildscript.sh
+++ b/ciscripts/buildscript.sh
@@ -7,3 +7,5 @@ fi
 sudo docker build --build-arg BUILD_STEP=2 -t=$IMAGE_NAME .
 sudo docker login --username=$DOCKER_USER --password=$DOCKER_PASS
 sudo docker push $IMAGE_NAME
+# make docker cleanup after itself and delete all exited containers
+sudo docker rm -v $(docker ps -a -q -f status=exited) || true

--- a/ciscripts/buildtests.sh
+++ b/ciscripts/buildtests.sh
@@ -2,3 +2,5 @@
 set -e
 sudo docker build --build-arg BUILD_STEP=1 -t=steemit/steem:tests .
 sudo docker run -v $WORKSPACE:/var/jenkins steemit/steem:tests cp -r /var/cobertura /var/jenkins
+# make docker cleanup after itself and delete all exited containers
+sudo docker rm -v $(docker ps -a -q -f status=exited) || true


### PR DESCRIPTION
This fixes two things with CI.

One: if one of the parllel jenkins jobs fails, the other will immediately halt, which is the desired effect.

Two: since jobs now run on multiple instances, docker cleanup needs to happen at the end of each build script in case instances are recycled and used again before being terminated.