### PR TITLE
Use statsd key push_transaction instead of push_tx

### DIFF
--- a/libraries/plugins/chain/chain_plugin.cpp
+++ b/libraries/plugins/chain/chain_plugin.cpp
@@ -131,9 +131,9 @@ struct write_request_visitor
 
       try
       {
-         STATSD_START_TIMER( "chain", "write_time", "push_tx", 1.0f )
+         STATSD_START_TIMER( "chain", "write_time", "push_transaction", 1.0f )
          db->push_transaction( *trx );
-         STATSD_STOP_TIMER( "chain", "write_time", "push_tx" )
+         STATSD_STOP_TIMER( "chain", "write_time", "push_transaction" )
 
          result = true;
       }


### PR DESCRIPTION
As per the acceptance criteria stated in #2511, we change the statsd key from `push_tx` to `push_transaction`.