### PR TITLE
rc_plugin.cpp:  Add account_create_with_delegation pre-apply hook

### DIFF
--- a/libraries/plugins/rc/rc_plugin.cpp
+++ b/libraries/plugins/rc/rc_plugin.cpp
@@ -579,6 +579,11 @@ struct pre_apply_operation_visitor
       regenerate( *account, *rc_account );
    }
 
+   void operator()( const account_create_with_delegation_operation& op )const
+   {
+      regenerate( op.creator );
+   }
+
    void operator()( const transfer_to_vesting_operation& op )const
    {
       account_name_type target = op.to.size() ? op.to : op.from;


### PR DESCRIPTION

This patch makes progress on #2626.

Replaying `develop` with `rc_plugin` dies with:

```
4100000 plugin_exception: plugin exception
Account steem max RC changed from 15636871956265 to 16871956265 without triggering an op, noticed on block 10642884
```

This patch should allow the replay to continue further.