### PR TITLE
Closes #2478 - Update default shared-file-size

### DIFF
--- a/libraries/plugins/chain/chain_plugin.cpp
+++ b/libraries/plugins/chain/chain_plugin.cpp
@@ -296,7 +296,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
    cfg.add_options()
          ("shared-file-dir", bpo::value<bfs::path>()->default_value("blockchain"),
             "the location of the chain shared memory files (absolute path or relative to application data dir)")
-         ("shared-file-size", bpo::value<string>()->default_value("24G"), "Size of the shared memory file. Default: 24G. If running a full node, increase this value to 200G.")
+         ("shared-file-size", bpo::value<string>()->default_value("54G"), "Size of the shared memory file. Default: 54G. If running a full node, increase this value to 200G.")
          ("shared-file-full-threshold", bpo::value<uint16_t>()->default_value(0),
             "A 2 precision percentage (0-10000) that defines the threshold for when to autoscale the shared memory file. Setting this to 0 disables autoscaling. Recommended value for consensus node is 9500 (95%). Full node is 9900 (99%)" )
          ("shared-file-scale-rate", bpo::value<uint16_t>()->default_value(0),


### PR DESCRIPTION
Currently when an instance of steemd is launched using the default config, steemd crashes after it fills up the shared memory file. This PR updates the default config value for `shared-file-size` to `54GB`.