### PR TITLE
Prevent crash on duplicate seed nodes

### DIFF
--- a/libraries/plugins/p2p/p2p_plugin.cpp
+++ b/libraries/plugins/p2p/p2p_plugin.cpp
@@ -150,7 +150,7 @@ private:
       handler_state&      _barrier;
       std::atomic_bool&   _activityFlag;
    };
-   
+
 };
 
 ////////////////////////////// Begin node_delegate Implementation //////////////////////////////
@@ -616,9 +616,6 @@ void p2p_plugin::plugin_initialize(const boost::program_options::variables_map& 
       }
    }
 
-   sort( my->seeds.begin(), my->seeds.end() );
-   my->seeds.erase( unique( my->seeds.begin(), my->seeds.end() ), my->seeds.end() );
-
    my->force_validate = options.at( "p2p-force-validate" ).as< bool >();
 
    if( !my->force_validate && options.at( "force-validate" ).as< bool >() )
@@ -650,9 +647,16 @@ void p2p_plugin::plugin_startup()
 
       for( const auto& seed : my->seeds )
       {
-         ilog("P2P adding seed node ${s}", ("s", seed));
-         my->node->add_node(seed);
-         my->node->connect_to_endpoint(seed);
+         try
+         {
+            ilog("P2P adding seed node ${s}", ("s", seed));
+            my->node->add_node(seed);
+            my->node->connect_to_endpoint(seed);
+         }
+         catch( graphene::net::already_connected_to_requested_peer& )
+         {
+            wlog( "Already connected to seed node ${s}. Is it specified twice in config?", ("s", seed) );
+         }
       }
 
       if( my->max_connections )
@@ -697,7 +701,7 @@ void p2p_plugin::plugin_shutdown() {
    my->running.store(false);
 
    ilog("P2P Plugin: checking handle_block and handle_transaction activity");
-   std::future_status bfState, tfState; 
+   std::future_status bfState, tfState;
    do
    {
       if(my->activeHandleBlock.load())


### PR DESCRIPTION
Not "fixing" the p2p code, but at least preventing unexpected exit.