### PR TITLE
2791 fix testnet witness keys

### DIFF
--- a/contrib/testnetinit.sh
+++ b/contrib/testnetinit.sh
@@ -25,8 +25,8 @@ chown steemd:steemd $HOME/testnet_datadir/config.ini
 
 cd $HOME
 
-echo chain-id = $CHAIN_ID >> config.ini
-echo chain-id = $CHAIN_ID >> testnet_datadir/config.ini
+echo -en '\nchain-id = $CHAIN_ID' >> config.ini
+echo -en '\nchain-id = $CHAIN_ID' >> testnet_datadir/config.ini
 
 mv /etc/nginx/nginx.conf /etc/nginx/nginx.original.conf
 cp /etc/nginx/steemd.nginx.conf /etc/nginx/nginx.conf
@@ -85,7 +85,7 @@ tinman submit --realtime -t http://127.0.0.1:9990 --signer $UTILS/sign_transacti
 i=0 ; while [ $i -lt 21 ] ; do echo witness = '"'init-$i'"' >> config.ini ; let i=i+1 ; done
 
 # add keys derived from shared secret to config file
-$UTILS/get_dev_key $SHARED_SECRET block-init-0:21 | cut -d '"' -f 4 | sed 's/^/private-key = /' >> config.ini
+$UTILS/get_dev_key $SHARED_SECRET init-0:21 | cut -d '"' -f 4 | sed 's/^/private-key = /' >> config.ini
 
 # let's get going
 echo steemd-testnet: bringing up witness / full node

--- a/contrib/testnetinit.sh
+++ b/contrib/testnetinit.sh
@@ -25,8 +25,14 @@ chown steemd:steemd $HOME/testnet_datadir/config.ini
 
 cd $HOME
 
-echo -en '\nchain-id = $CHAIN_ID' >> config.ini
-echo -en '\nchain-id = $CHAIN_ID' >> testnet_datadir/config.ini
+echo -en '\n' >> config.ini
+echo -en '\n' >> testnet_datadir/config.ini
+
+echo chain-id = $CHAIN_ID >> config.ini
+echo chain-id = $CHAIN_ID >> testnet_datadir/config.ini
+
+echo -en '\n' >> config.ini
+echo -en '\n' >> testnet_datadir/config.ini
 
 mv /etc/nginx/nginx.conf /etc/nginx/nginx.original.conf
 cp /etc/nginx/steemd.nginx.conf /etc/nginx/nginx.conf
@@ -79,13 +85,15 @@ echo steemd-testnet: pipelining transactions into fastgen node, this may take so
   cat txgen.list \
 ) | \
 tinman keysub --get-dev-key $UTILS/get_dev_key | \
-tinman submit --realtime -t http://127.0.0.1:9990 --signer $UTILS/sign_transaction -f fail.json
+tinman submit --realtime -t http://127.0.0.1:9990 --signer $UTILS/sign_transaction -f fail.json &
+
+sleep 120
 
 # add witness names to config file
 i=0 ; while [ $i -lt 21 ] ; do echo witness = '"'init-$i'"' >> config.ini ; let i=i+1 ; done
 
 # add keys derived from shared secret to config file
-$UTILS/get_dev_key $SHARED_SECRET init-0:21 | cut -d '"' -f 4 | sed 's/^/private-key = /' >> config.ini
+$UTILS/get_dev_key $SHARED_SECRET block-init-0:21 | cut -d '"' -f 4 | sed 's/^/private-key = /' >> config.ini
 
 # let's get going
 echo steemd-testnet: bringing up witness / full node


### PR DESCRIPTION
Closes #2791 

The witness key issue is a separate one, portions of github.com/steemit/tinman/issues/57 have to be completed for that and that work is separate from this.

This solves the chain-id bug, and also runs `tinman submit` in the background so that `seed` can begin getting blocks from `bootstrap` while `submit` is still running. This is confirmed working.