### PR TITLE
Fix signing when account auths are present

### DIFF
--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -550,7 +550,7 @@ public:
       signed_transaction tx,
       bool broadcast = false )
    {
-      static const authority null_auth( 0, public_key_type(), 0 );
+      static const authority null_auth( 1, public_key_type(), 0 );
       flat_set< account_name_type >   req_active_approvals;
       flat_set< account_name_type >   req_owner_approvals;
       flat_set< account_name_type >   req_posting_approvals;


### PR DESCRIPTION
The "null auth" was a trivially satisfied auth, which meant when signatures were minimized all signatures were stripped. This makes the auth impossible, which will leave key auth sigs in place.