### PR TITLE
wallet.cpp:  Fix typo introduced in #2876

### DIFF
--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -700,7 +700,7 @@ public:
          {
             auto maybe_account = get_account_from_lut( account_name );
             if( maybe_account.valid() )
-               return (*maybe_account)->active;
+               return (*maybe_account)->owner;
 
             return null_auth;
          },
@@ -708,7 +708,7 @@ public:
          {
             auto maybe_account = get_account_from_lut( account_name );
             if( maybe_account.valid() )
-               return (*maybe_account)->active;
+               return (*maybe_account)->posting;
 
             return null_auth;
          },

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -550,7 +550,7 @@ public:
       signed_transaction tx,
       bool broadcast = false )
    {
-      static const authority null_auth( 0, public_key_type(), 0 );
+      static const authority null_auth( 1, public_key_type(), 0 );
       flat_set< account_name_type >   req_active_approvals;
       flat_set< account_name_type >   req_owner_approvals;
       flat_set< account_name_type >   req_posting_approvals;


### PR DESCRIPTION
I found a typo in #2876 code when reviewing PR #2888.  This PR is built on PR #2888, so #2888 should be merged first.