### PR TITLE
Implement serialize_set_properties helper target

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -3383,8 +3383,16 @@ try {
 #endif
             if( has_hardfork( STEEM_HARDFORK_0_14__230 ) )
             {
+               // This block limits the effective median price to force SBD to remain at or
+               // below 10% of the combined market cap of STEEM and SBD.
+               //
+               // For example, if we have 500 STEEM and 100 SBD, the price is limited to
+               // 900 SBD / 500 STEEM which works out to be $1.80.  At this price, 500 Steem
+               // would be valued at 500 * $1.80 = $900.  100 SBD is by definition always $100,
+               // so the combined market cap is $900 + $100 = $1000.
+
                const auto& gpo = get_dynamic_global_properties();
-               price min_price( asset( 9 * gpo.current_sbd_supply.amount, SBD_SYMBOL ), gpo.current_supply ); // This price limits SBD to 10% market cap
+               price min_price( asset( 9 * gpo.current_sbd_supply.amount, SBD_SYMBOL ), gpo.current_supply );
 
                if( min_price > fho.current_median_history )
                   fho.current_median_history = min_price;

--- a/programs/util/CMakeLists.txt
+++ b/programs/util/CMakeLists.txt
@@ -43,6 +43,19 @@ install( TARGETS
    ARCHIVE DESTINATION lib
 )
 
+add_executable( serialize_set_properties serialize_set_properties.cpp )
+
+target_link_libraries( serialize_set_properties
+                       PRIVATE steem_chain steem_protocol steem_utilities fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+
+install( TARGETS
+   serialize_set_properties
+
+   RUNTIME DESTINATION bin
+   LIBRARY DESTINATION lib
+   ARCHIVE DESTINATION lib
+)
+
 add_executable( inflation_model inflation_model.cpp )
 target_link_libraries( inflation_model
                        PRIVATE steem_chain steem_protocol fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )

--- a/programs/util/serialize_set_properties.cpp
+++ b/programs/util/serialize_set_properties.cpp
@@ -1,0 +1,95 @@
+
+#include <steem/protocol/operations.hpp>
+
+#include <fc/io/json.hpp>
+
+#include <boost/algorithm/string.hpp>
+
+using namespace steem::protocol;
+using boost::container::flat_map;
+using std::string;
+using std::vector;
+
+struct witness_properties
+{
+   // Chain properties
+   fc::optional< asset >               account_creation_fee;
+   fc::optional< uint32_t >            maximum_block_size;
+   fc::optional< uint16_t >            sbd_interest_rate;
+   fc::optional< int32_t >             account_subsidy_budget;
+   fc::optional< uint32_t >            account_subsidy_decay;
+
+   // Per-witness fields
+   fc::optional< public_key_type >     key;
+   fc::optional< public_key_type >     new_signing_key;
+   fc::optional< price >               sbd_exchange_rate;
+   fc::optional< std::string >         url;
+};
+
+FC_REFLECT( witness_properties,
+   (account_creation_fee)
+   (maximum_block_size)
+   (sbd_interest_rate)
+   (account_subsidy_budget)
+   (account_subsidy_decay)
+
+   (key)
+   (new_signing_key)
+   (sbd_exchange_rate)
+   (url)
+   );
+
+class serialize_member_visitor
+{
+   public:
+      serialize_member_visitor( const witness_properties& in, flat_map< string, vector<char> >& out )
+         : _in(in), _out(out) {}
+
+      template<typename Member, class Class, Member (Class::*member)>
+      void operator()( const char* name )const
+      {
+         if( !(_in.*member) )
+            return;
+
+         vector<char> v = fc::raw::pack_to_vector( *(_in.*member) );
+         _out.emplace( name, std::move( v ) );
+      }
+
+   private:
+      const witness_properties& _in;
+      flat_map< string, vector<char> >& _out;
+};
+
+int main( int argc, char** argv, char** envp )
+{
+   // Serialize the witness_set_properties_operation
+   // Take a sequence of witness_properties, one per line
+   while( std::cin )
+   {
+      std::string line;
+      std::getline( std::cin, line );
+      boost::trim(line);
+      if( line == "" )
+         continue;
+      try
+      {
+         fc::variant v = fc::json::from_string( line, fc::json::strict_parser );
+         witness_properties wprops;
+         witness_set_properties_operation op;
+         fc::from_variant( v, wprops );
+         serialize_member_visitor vtor( wprops, op.props );
+
+         // For each field
+         fc::reflector< witness_properties >::visit( vtor );
+
+         std::cout << fc::json::to_string( op.props ) << std::endl;
+      }
+      catch( const fc::exception& e )
+      {
+         elog( "Error: ${e}", ("e", e.to_detail_string()) );
+         return 1;
+      }
+   }
+
+   return 0;
+}


### PR DESCRIPTION
This is a simple C++ program which serializes the `props` member of `witness_set_properties_operation`.  I'm not sure whether this should be included in `steemd`, or if a different approach is better.  If we decide it shouldn't be merged, I'm willing to accept that.