### PR TITLE
Remove unused max_rc field

### DIFF
--- a/libraries/plugins/apis/rc_api/rc_api.cpp
+++ b/libraries/plugins/apis/rc_api/rc_api.cpp
@@ -3,6 +3,8 @@
 
 #include <steem/plugins/rc/rc_objects.hpp>
 
+#include <steem/chain/account_object.hpp>
+
 #include <fc/variant_object.hpp>
 #include <fc/reflect/variant.hpp>
 
@@ -70,11 +72,13 @@ DEFINE_API_IMPL( rc_api_impl, find_rc_accounts )
       if( rc_account == nullptr )
          continue;
 
+      const account_object& account = _db.get< account_object, by_name >( a );
+
       rc_account_api_object api_rc_account;
       api_rc_account.account = rc_account->account;
       api_rc_account.rc_manabar = rc_account->rc_manabar;
       api_rc_account.max_rc_creation_adjustment = rc_account->max_rc_creation_adjustment;
-      api_rc_account.max_rc = rc_account->max_rc;
+      api_rc_account.max_rc = get_maximum_rc( account, *rc_account );
 
       result.rc_accounts.emplace_back( api_rc_account );
    }

--- a/libraries/plugins/rc/include/steem/plugins/rc/rc_objects.hpp
+++ b/libraries/plugins/rc/include/steem/plugins/rc/rc_objects.hpp
@@ -68,12 +68,13 @@ class rc_account_object : public object< rc_account_object_type, rc_account_obje
       account_name_type     account;
       steem::chain::util::manabar   rc_manabar;
       asset                 max_rc_creation_adjustment = asset( 0, VESTS_SYMBOL );
-      int64_t               max_rc = 0;
 
       // This is used for bug-catching, to match that the vesting shares in a
       // pre-op are equal to what they were at the last post-op.
       int64_t               last_max_rc = 0;
 };
+
+int64_t get_maximum_rc( const steem::chain::account_object& account, const rc_account_object& rc_account );
 
 using namespace boost::multi_index;
 
@@ -115,7 +116,6 @@ FC_REFLECT( steem::plugins::rc::rc_account_object,
    (account)
    (rc_manabar)
    (max_rc_creation_adjustment)
-   (max_rc)
    (last_max_rc)
    )
 CHAINBASE_SET_INDEX_TYPE( steem::plugins::rc::rc_account_object, steem::plugins::rc::rc_account_index )

--- a/libraries/plugins/rc/rc_plugin.cpp
+++ b/libraries/plugins/rc/rc_plugin.cpp
@@ -92,16 +92,6 @@ inline int64_t get_next_vesting_withdrawal( const account_object& account )
    return is_done ? 0 : next_withdrawal;
 }
 
-int64_t get_maximum_rc( const account_object& account, const rc_account_object& rc_account )
-{
-   int64_t result = account.vesting_shares.amount.value;
-   result = fc::signed_sat_sub( result, account.delegated_vesting_shares.amount.value );
-   result = fc::signed_sat_add( result, account.received_vesting_shares.amount.value );
-   result = fc::signed_sat_add( result, rc_account.max_rc_creation_adjustment.amount.value );
-   result = fc::signed_sat_sub( result, get_next_vesting_withdrawal( account ) );
-   return result;
-}
-
 template< bool account_may_exist = false >
 void create_rc_account( database& db, uint32_t now, const account_object& account, asset max_rc_creation_adjustment )
 {
@@ -119,7 +109,6 @@ void create_rc_account( database& db, uint32_t now, const account_object& accoun
       rca.rc_manabar.current_mana = get_maximum_rc( account, rca );
       rca.rc_manabar.last_update_time = now;
       rca.max_rc_creation_adjustment = max_rc_creation_adjustment;
-      rca.max_rc = rca.rc_manabar.current_mana;
       rca.last_max_rc = get_maximum_rc( account, rca );
    } );
 }
@@ -993,6 +982,16 @@ exp_rc_data::~exp_rc_data() {}
 void exp_rc_data::to_variant( fc::variant& v )const
 {
    fc::to_variant( *this, v );
+}
+
+int64_t get_maximum_rc( const account_object& account, const rc_account_object& rc_account )
+{
+   int64_t result = account.vesting_shares.amount.value;
+   result = fc::signed_sat_sub( result, account.delegated_vesting_shares.amount.value );
+   result = fc::signed_sat_add( result, account.received_vesting_shares.amount.value );
+   result = fc::signed_sat_add( result, rc_account.max_rc_creation_adjustment.amount.value );
+   result = fc::signed_sat_sub( result, detail::get_next_vesting_withdrawal( account ) );
+   return result;
 }
 
 } } } // steem::plugins::rc


### PR DESCRIPTION

This removes the unused `max_rc` field from the `rc_account_object` and properly sets the return value in the API.
