### PR TITLE
Bump broadcaster shared file size

### DIFF
--- a/contrib/config-for-broadcaster.ini
+++ b/contrib/config-for-broadcaster.ini
@@ -26,7 +26,7 @@ plugin = database_api witness_api condenser_api network_broadcast_api rc_api
 # shared-file-dir = "blockchain"
 
 # Size of the shared memory file. Default: 54G
-shared-file-size = 24G
+shared-file-size = 70G
 
 # Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.
 # checkpoint =


### PR DESCRIPTION
As part of dusting off the old broadcaster/broadcastsync EB apps, we need to increase the default shared memory size.