### PR TITLE
Fix a bug on minimum voting mana requirement

### DIFF
--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -1794,7 +1794,7 @@ void hf20_vote_evaluator( const vote_operation& o, database& _db )
 
    if( !_db.has_hardfork( STEEM_HARDFORK_0_21__3034 ) )
    {
-      FC_ASSERT( voter.voting_manabar.current_mana > 0, "Account does not have enough mana to vote." );
+      FC_ASSERT( voter.voting_manabar.current_mana >= 0, "Account does not have enough mana to vote." );
    }
 
    int16_t abs_weight = abs( o.weight );

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -1791,7 +1791,7 @@ void hf20_vote_evaluator( const vote_operation& o, database& _db )
       util::manabar_params params( util::get_effective_vesting_shares( a ), STEEM_VOTING_MANA_REGENERATION_SECONDS );
       a.voting_manabar.regenerate_mana( params, now );
    });
-   FC_ASSERT( voter.voting_manabar.current_mana > 0, "Account does not have enough mana to vote." );
+   FC_ASSERT( voter.voting_manabar.current_mana >= 0, "Account does not have enough mana to vote." );
 
    int16_t abs_weight = abs( o.weight );
    uint128_t used_mana = ( uint128_t( voter.voting_manabar.current_mana ) * abs_weight * 60 * 60 * 24 ) / STEEM_100_PERCENT;

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -1791,7 +1791,11 @@ void hf20_vote_evaluator( const vote_operation& o, database& _db )
       util::manabar_params params( util::get_effective_vesting_shares( a ), STEEM_VOTING_MANA_REGENERATION_SECONDS );
       a.voting_manabar.regenerate_mana( params, now );
    });
-   FC_ASSERT( voter.voting_manabar.current_mana >= 0, "Account does not have enough mana to vote." );
+
+   if( !_db.has_hardfork( STEEM_HARDFORK_0_21__3034 ) )
+   {
+      FC_ASSERT( voter.voting_manabar.current_mana > 0, "Account does not have enough mana to vote." );
+   }
 
    int16_t abs_weight = abs( o.weight );
    uint128_t used_mana = ( uint128_t( voter.voting_manabar.current_mana ) * abs_weight * 60 * 60 * 24 ) / STEEM_100_PERCENT;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1332279/46518892-65f32400-c8b1-11e8-8bd9-dd846e67c96c.png)

A new user will have 0 SP and 0 VP, but votings should go through even though it has zero effect on the rewards.

Currently the code change was missing, so new users are getting
`{“error”:“server_error”,“error_description”:“voter.voting_manabar.current_mana > 0: Account does not have enough mana to vote.“}` when they vote.

Temporary work-around: Delegate 0.001 SP to the new account

