### PR TITLE
Remove witness_api from configs

### DIFF
--- a/contrib/config-for-broadcaster.ini
+++ b/contrib/config-for-broadcaster.ini
@@ -11,7 +11,7 @@ log-logger = {"name":"p2p","level":"info","appender":"stderr"}
 # Plugin(s) to enable, may be specified multiple times
 plugin = webserver p2p json_rpc witness
 
-plugin = database_api witness_api condenser_api network_broadcast_api rc_api
+plugin = database_api condenser_api network_broadcast_api rc_api
 
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times
 # account-history-track-account-range =

--- a/contrib/config-for-docker.ini
+++ b/contrib/config-for-docker.ini
@@ -11,7 +11,7 @@ log-logger = {"name":"p2p","level":"info","appender":"stderr"}
 # Plugin(s) to enable, may be specified multiple times
 plugin = webserver p2p json_rpc witness
 
-plugin = database_api witness_api condenser_api rc_api
+plugin = database_api condenser_api rc_api
 
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times
 # account-history-track-account-range =

--- a/contrib/fullnode.config.ini
+++ b/contrib/fullnode.config.ini
@@ -11,7 +11,7 @@ log-logger = {"name":"p2p","level":"info","appender":"stderr"}
 # Plugin(s) to enable, may be specified multiple times
 plugin = webserver p2p json_rpc witness account_by_key tags follow market_history
 
-plugin = database_api account_by_key_api network_broadcast_api tags_api follow_api market_history_api witness_api condenser_api block_api rc_api
+plugin = database_api account_by_key_api network_broadcast_api tags_api follow_api market_history_api condenser_api block_api rc_api
 
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times
 # account-history-track-account-range =

--- a/contrib/fullnode.opswhitelist.config.ini
+++ b/contrib/fullnode.opswhitelist.config.ini
@@ -11,7 +11,7 @@ log-logger = {"name":"p2p","level":"info","appender":"stderr"}
 # Plugin(s) to enable, may be specified multiple times
 plugin = webserver p2p json_rpc witness account_by_key tags follow market_history account_history
 
-plugin = database_api account_by_key_api network_broadcast_api tags_api follow_api market_history_api witness_api condenser_api account_history_api rc_api
+plugin = database_api account_by_key_api network_broadcast_api tags_api follow_api market_history_api condenser_api account_history_api rc_api
 
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times
 # account-history-track-account-range =


### PR DESCRIPTION
A follow up to the changes in #3029. In order for these config files to be valid, this API must be removed.