### PR TITLE
Separate source file for core indexes, misc. cleanup

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library( steem_chain
 
              # As database takes the longest to compile, start it first
              database.cpp
+             index.cpp
 
              smt_evaluator.cpp
              smt_objects/smt_market_maker.cpp

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -1,3 +1,4 @@
+
 #include <steem/protocol/steem_operations.hpp>
 
 #include <steem/chain/block_summary_object.hpp>
@@ -9,7 +10,6 @@
 #include <steem/chain/evaluator_registry.hpp>
 #include <steem/chain/global_property_object.hpp>
 #include <steem/chain/history_object.hpp>
-#include <steem/chain/index.hpp>
 #include <steem/chain/pending_required_action_object.hpp>
 #include <steem/chain/pending_optional_action_object.hpp>
 #include <steem/chain/smt_objects.hpp>
@@ -2580,46 +2580,11 @@ std::shared_ptr< custom_operation_interpreter > database::get_custom_json_evalua
    return std::shared_ptr< custom_operation_interpreter >();
 }
 
+void initialize_core_indexes( database& db );
+
 void database::initialize_indexes()
 {
-   add_core_index< dynamic_global_property_index           >(*this);
-   add_core_index< account_index                           >(*this);
-   add_core_index< account_authority_index                 >(*this);
-   add_core_index< witness_index                           >(*this);
-   add_core_index< transaction_index                       >(*this);
-   add_core_index< block_summary_index                     >(*this);
-   add_core_index< witness_schedule_index                  >(*this);
-   add_core_index< comment_index                           >(*this);
-   add_core_index< comment_content_index                   >(*this);
-   add_core_index< comment_vote_index                      >(*this);
-   add_core_index< witness_vote_index                      >(*this);
-   add_core_index< limit_order_index                       >(*this);
-   add_core_index< feed_history_index                      >(*this);
-   add_core_index< convert_request_index                   >(*this);
-   add_core_index< liquidity_reward_balance_index          >(*this);
-   add_core_index< operation_index                         >(*this);
-   add_core_index< account_history_index                   >(*this);
-   add_core_index< hardfork_property_index                 >(*this);
-   add_core_index< withdraw_vesting_route_index            >(*this);
-   add_core_index< owner_authority_history_index           >(*this);
-   add_core_index< account_recovery_request_index          >(*this);
-   add_core_index< change_recovery_account_request_index   >(*this);
-   add_core_index< escrow_index                            >(*this);
-   add_core_index< savings_withdraw_index                  >(*this);
-   add_core_index< decline_voting_rights_request_index     >(*this);
-   add_core_index< reward_fund_index                       >(*this);
-   add_core_index< vesting_delegation_index                >(*this);
-   add_core_index< vesting_delegation_expiration_index     >(*this);
-   add_core_index< pending_required_action_index           >(*this);
-   add_core_index< pending_optional_action_index           >(*this);
-#ifdef STEEM_ENABLE_SMT
-   add_core_index< smt_token_index                         >(*this);
-   add_core_index< smt_event_token_index                   >(*this);
-   add_core_index< account_regular_balance_index           >(*this);
-   add_core_index< account_rewards_balance_index           >(*this);
-   add_core_index< nai_pool_index                          >(*this);
-#endif
-
+   initialize_core_indexes( *this );
    _plugin_index_signal();
 }
 
@@ -5442,8 +5407,5 @@ optional< chainbase::database::session >& database::pending_transaction_session(
 {
    return _pending_tx_session;
 }
-
-index_info::index_info() {}
-index_info::~index_info() {}
 
 } } //steem::chain

--- a/libraries/chain/include/steem/chain/steem_fwd.hpp
+++ b/libraries/chain/include/steem/chain/steem_fwd.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-// This header forward-declare spack/unpack and to/from variant functions for Steem types.
+// This header forward-declares pack/unpack and to/from variant functions for Steem types.
 // These declarations need to be as early as possible to prevent compiler errors.
 
 #include <chainbase/allocators.hpp>
@@ -31,17 +31,5 @@ template<typename Stream, typename K, typename V, typename C, typename A>
 void pack( Stream& s, const boost::interprocess::flat_map< K, V, C, A >& value );
 template<typename Stream, typename K, typename V, typename C, typename A>
 void unpack( Stream& s, boost::interprocess::flat_map< K, V, C, A >& value );
-
-/*
-template<typename Stream, typename K, typename V, typename C, typename A>
-void pack( Stream& s, const boost::interprocess::map< K, V, C, A >& value );
-template<typename Stream, typename K, typename V, typename C, typename A>
-void unpack( Stream& s, boost::interprocess::map< K, V, C, A >& value );
-
-template<typename Stream, typename E, typename C, typename A>
-void pack( Stream& s, const boost::interprocess::set< E, C, A >& value );
-template<typename Stream, typename E, typename C, typename A>
-void unpack( Stream& s, boost::interprocess::set< E, C, A >& value );
-*/
 
 } }

--- a/libraries/chain/include/steem/chain/steem_fwd.hpp
+++ b/libraries/chain/include/steem/chain/steem_fwd.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+// This header forward-declare spack/unpack and to/from variant functions for Steem types.
+// These declarations need to be as early as possible to prevent compiler errors.
+
+#include <chainbase/allocators.hpp>
+
+namespace chainbase {
+template< typename T >
+class oid;
+}
+
+namespace fc { namespace raw {
+
+template<typename Stream, typename T>
+inline void pack( Stream& s, const chainbase::oid<T>& id );
+template<typename Stream, typename T>
+inline void unpack( Stream& s, chainbase::oid<T>& id );
+
+template<typename Stream>
+inline void pack( Stream& s, const chainbase::shared_string& ss );
+template<typename Stream>
+inline void unpack( Stream& s, chainbase::shared_string& ss );
+
+template<typename Stream, typename E, typename A>
+void pack( Stream& s, const boost::interprocess::deque< E, A >& value );
+template<typename Stream, typename E, typename A>
+void unpack( Stream& s, boost::interprocess::deque< E, A >& value );
+
+template<typename Stream, typename K, typename V, typename C, typename A>
+void pack( Stream& s, const boost::interprocess::flat_map< K, V, C, A >& value );
+template<typename Stream, typename K, typename V, typename C, typename A>
+void unpack( Stream& s, boost::interprocess::flat_map< K, V, C, A >& value );
+
+/*
+template<typename Stream, typename K, typename V, typename C, typename A>
+void pack( Stream& s, const boost::interprocess::map< K, V, C, A >& value );
+template<typename Stream, typename K, typename V, typename C, typename A>
+void unpack( Stream& s, boost::interprocess::map< K, V, C, A >& value );
+
+template<typename Stream, typename E, typename C, typename A>
+void pack( Stream& s, const boost::interprocess::set< E, C, A >& value );
+template<typename Stream, typename E, typename C, typename A>
+void unpack( Stream& s, boost::interprocess::set< E, C, A >& value );
+*/
+
+} }

--- a/libraries/chain/include/steem/chain/steem_object_types.hpp
+++ b/libraries/chain/include/steem/chain/steem_object_types.hpp
@@ -169,117 +169,125 @@ enum bandwidth_type
 
 namespace fc
 {
-   class variant;
-   inline void to_variant( const steem::chain::shared_string& s, variant& var )
+class variant;
+
+inline void to_variant( const steem::chain::shared_string& s, variant& var )
+{
+   var = fc::string( steem::chain::to_string( s ) );
+}
+
+inline void from_variant( const variant& var, steem::chain::shared_string& s )
+{
+   auto str = var.as_string();
+   s.assign( str.begin(), str.end() );
+}
+
+template<typename T>
+void to_variant( const chainbase::oid<T>& var,  variant& vo )
+{
+   vo = var._id;
+}
+
+template<typename T>
+void from_variant( const variant& vo, chainbase::oid<T>& var )
+{
+   var._id = vo.as_int64();
+}
+
+namespace raw
+{
+
+template<typename Stream, typename T>
+void pack( Stream& s, const chainbase::oid<T>& id )
+{
+   s.write( (const char*)&id._id, sizeof(id._id) );
+}
+
+template<typename Stream, typename T>
+void unpack( Stream& s, chainbase::oid<T>& id )
+{
+   s.read( (char*)&id._id, sizeof(id._id));
+}
+
+template< typename Stream >
+void pack( Stream& s, const chainbase::shared_string& ss )
+{
+   std::string str = steem::chain::to_string( ss );
+   fc::raw::pack( s, str );
+}
+
+template< typename Stream >
+void unpack( Stream& s, chainbase::shared_string& ss )
+{
+   std::string str;
+   fc::raw::unpack( s, str );
+   steem::chain::from_string( ss, str );
+}
+
+template< typename Stream, typename E, typename A >
+void pack( Stream& s, const boost::interprocess::deque<E, A>& dq )
+{
+   // This could be optimized
+   std::vector<E> temp;
+   std::copy( dq.begin(), dq.end(), std::back_inserter(temp) );
+   pack( s, temp );
+}
+
+template< typename Stream, typename E, typename A >
+void unpack( Stream& s, boost::interprocess::deque<E, A>& dq )
+{
+   // This could be optimized
+   std::vector<E> temp;
+   unpack( s, temp );
+   std::copy( temp.begin(), temp.end(), std::back_inserter(dq) );
+}
+
+template< typename Stream, typename K, typename V, typename C, typename A >
+void pack( Stream& s, const boost::interprocess::flat_map< K, V, C, A >& value )
+{
+   fc::raw::pack( s, unsigned_int((uint32_t)value.size()) );
+   auto itr = value.begin();
+   auto end = value.end();
+   while( itr != end )
    {
-      var = fc::string( steem::chain::to_string( s ) );
-   }
-
-   inline void from_variant( const variant& var, steem::chain::shared_string& s )
-   {
-      auto str = var.as_string();
-      s.assign( str.begin(), str.end() );
-   }
-
-   template<typename T>
-   void to_variant( const chainbase::oid<T>& var,  variant& vo )
-   {
-      vo = var._id;
-   }
-   template<typename T>
-   void from_variant( const variant& vo, chainbase::oid<T>& var )
-   {
-      var._id = vo.as_int64();
-   }
-
-   namespace raw {
-      template<typename Stream, typename T>
-      inline void pack( Stream& s, const chainbase::oid<T>& id )
-      {
-         s.write( (const char*)&id._id, sizeof(id._id) );
-      }
-      template<typename Stream, typename T>
-      inline void unpack( Stream& s, chainbase::oid<T>& id )
-      {
-         s.read( (char*)&id._id, sizeof(id._id));
-      }
-
-      template< typename Stream >
-      inline void pack( Stream& s, const chainbase::shared_string& ss )
-      {
-         std::string str = steem::chain::to_string( ss );
-         fc::raw::pack( s, str );
-      }
-
-      template< typename Stream >
-      inline void unpack( Stream& s, chainbase::shared_string& ss )
-      {
-         std::string str;
-         fc::raw::unpack( s, str );
-         steem::chain::from_string( ss, str );
-      }
-
-      template< typename Stream, typename E, typename A >
-      inline void pack( Stream& s, const boost::interprocess::deque<E, A>& dq )
-      {
-         // This could be optimized
-         std::vector<E> temp;
-         std::copy( dq.begin(), dq.end(), std::back_inserter(temp) );
-         pack( s, temp );
-      }
-
-      template< typename Stream, typename E, typename A >
-      inline void unpack( Stream& s, boost::interprocess::deque<E, A>& dq )
-      {
-         // This could be optimized
-         std::vector<E> temp;
-         unpack( s, temp );
-         std::copy( temp.begin(), temp.end(), std::back_inserter(dq) );
-      }
-
-      template< typename Stream, typename K, typename V, typename C, typename A >
-      inline void pack( Stream& s, const boost::interprocess::flat_map< K, V, C, A >& value )
-      {
-         fc::raw::pack( s, unsigned_int((uint32_t)value.size()) );
-         auto itr = value.begin();
-         auto end = value.end();
-         while( itr != end )
-         {
-           fc::raw::pack( s, *itr );
-           ++itr;
-         }
-      }
-
-      template< typename Stream, typename K, typename V, typename C, typename A >
-      inline void unpack( Stream& s, boost::interprocess::flat_map< K, V, C, A >& value )
-      {
-         unsigned_int size;
-         unpack( s, size );
-         value.clear();
-         FC_ASSERT( size.value*(sizeof(K)+sizeof(V)) < MAX_ARRAY_ALLOC_SIZE );
-         value.reserve(size.value);
-         for( uint32_t i = 0; i < size.value; ++i )
-         {
-             std::pair<K,V> tmp;
-             fc::raw::unpack( s, tmp );
-             value.insert( std::move(tmp) );
-         }
-      }
-
-#ifndef ENABLE_STD_ALLOCATOR
-      template< typename T >
-      inline T unpack_from_vector( const steem::chain::buffer_type& s )
-      { try  {
-         T tmp;
-         if( s.size() ) {
-         datastream<const char*>  ds( s.data(), size_t(s.size()) );
-         fc::raw::unpack(ds,tmp);
-         }
-         return tmp;
-      } FC_RETHROW_EXCEPTIONS( warn, "error unpacking ${type}", ("type",fc::get_typename<T>::name() ) ) }
-#endif
+      fc::raw::pack( s, *itr );
+      ++itr;
    }
 }
+
+template< typename Stream, typename K, typename V, typename C, typename A >
+void unpack( Stream& s, boost::interprocess::flat_map< K, V, C, A >& value )
+{
+   unsigned_int size;
+   unpack( s, size );
+   value.clear();
+   FC_ASSERT( size.value*(sizeof(K)+sizeof(V)) < MAX_ARRAY_ALLOC_SIZE );
+   value.reserve(size.value);
+   for( uint32_t i = 0; i < size.value; ++i )
+   {
+      std::pair<K,V> tmp;
+      fc::raw::unpack( s, tmp );
+      value.insert( std::move(tmp) );
+   }
+}
+
+#ifndef ENABLE_STD_ALLOCATOR
+template< typename T >
+T unpack_from_vector( const steem::chain::buffer_type& s )
+{
+   try
+   {
+      T tmp;
+      if( s.size() )
+      {
+         datastream<const char*>  ds( s.data(), size_t(s.size()) );
+         fc::raw::unpack(ds,tmp);
+      }
+      return tmp;
+   } FC_RETHROW_EXCEPTIONS( warn, "error unpacking ${type}", ("type",fc::get_typename<T>::name() ) )
+}
+#endif
+} } // namespace fc::raw
 
 FC_REFLECT_ENUM( steem::chain::object_type,
                  (dynamic_global_property_object_type)

--- a/libraries/chain/index.cpp
+++ b/libraries/chain/index.cpp
@@ -1,0 +1,61 @@
+
+#include <steem/chain/steem_fwd.hpp>
+
+#include <steem/chain/index.hpp>
+
+#include <steem/chain/block_summary_object.hpp>
+#include <steem/chain/history_object.hpp>
+#include <steem/chain/pending_required_action_object.hpp>
+#include <steem/chain/pending_optional_action_object.hpp>
+#include <steem/chain/smt_objects.hpp>
+#include <steem/chain/steem_objects.hpp>
+#include <steem/chain/transaction_object.hpp>
+#include <steem/chain/witness_schedule.hpp>
+
+namespace steem { namespace chain {
+
+void initialize_core_indexes( database& db )
+{
+   add_core_index< dynamic_global_property_index           >( db );
+   add_core_index< account_index                           >( db );
+   add_core_index< account_authority_index                 >( db );
+   add_core_index< witness_index                           >( db );
+   add_core_index< transaction_index                       >( db );
+   add_core_index< block_summary_index                     >( db );
+   add_core_index< witness_schedule_index                  >( db );
+   add_core_index< comment_index                           >( db );
+   add_core_index< comment_content_index                   >( db );
+   add_core_index< comment_vote_index                      >( db );
+   add_core_index< witness_vote_index                      >( db );
+   add_core_index< limit_order_index                       >( db );
+   add_core_index< feed_history_index                      >( db );
+   add_core_index< convert_request_index                   >( db );
+   add_core_index< liquidity_reward_balance_index          >( db );
+   add_core_index< operation_index                         >( db );
+   add_core_index< account_history_index                   >( db );
+   add_core_index< hardfork_property_index                 >( db );
+   add_core_index< withdraw_vesting_route_index            >( db );
+   add_core_index< owner_authority_history_index           >( db );
+   add_core_index< account_recovery_request_index          >( db );
+   add_core_index< change_recovery_account_request_index   >( db );
+   add_core_index< escrow_index                            >( db );
+   add_core_index< savings_withdraw_index                  >( db );
+   add_core_index< decline_voting_rights_request_index     >( db );
+   add_core_index< reward_fund_index                       >( db );
+   add_core_index< vesting_delegation_index                >( db );
+   add_core_index< vesting_delegation_expiration_index     >( db );
+   add_core_index< pending_required_action_index           >( db );
+   add_core_index< pending_optional_action_index           >( db );
+#ifdef STEEM_ENABLE_SMT
+   add_core_index< smt_token_index                         >( db );
+   add_core_index< smt_event_token_index                   >( db );
+   add_core_index< account_regular_balance_index           >( db );
+   add_core_index< account_rewards_balance_index           >( db );
+   add_core_index< nai_pool_index                          >( db );
+#endif
+}
+
+index_info::index_info() {}
+index_info::~index_info() {}
+
+} }

--- a/libraries/chainbase/include/chainbase/allocators.hpp
+++ b/libraries/chainbase/include/chainbase/allocators.hpp
@@ -11,6 +11,7 @@
 #include <boost/interprocess/sync/interprocess_sharable_mutex.hpp>
 #include <boost/interprocess/sync/sharable_lock.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
+#include <boost/thread/locks.hpp>
 
 #include <type_traits>
 
@@ -18,7 +19,7 @@ namespace chainbase {
 
    namespace bip = boost::interprocess;
 
-   #ifdef ENABLE_STD_ALLOCATOR 
+   #ifdef ENABLE_STD_ALLOCATOR
       template< typename T >
       using allocator = std::allocator< T >;
 
@@ -51,7 +52,6 @@ namespace chainbase {
                               bip::vector<T, allocator<T> >
                               >::type;
 
-   
    template< typename FIRST_TYPE, typename SECOND_TYPE >
    using t_pair = std::pair< FIRST_TYPE, SECOND_TYPE >;
 

--- a/libraries/chainbase/include/chainbase/allocators.hpp
+++ b/libraries/chainbase/include/chainbase/allocators.hpp
@@ -64,22 +64,9 @@ namespace chainbase {
       bip::flat_map< KEY_TYPE, VALUE_TYPE, LESS_FUNC, allocator< t_pair< KEY_TYPE, VALUE_TYPE > > >
       >::type;
 
-   template< typename KEY_TYPE, typename VALUE_TYPE, typename LESS_FUNC = std::less<KEY_TYPE>>
-   using t_map = typename std::conditional< _ENABLE_STD_ALLOCATOR,
-                              std::map< KEY_TYPE, VALUE_TYPE, LESS_FUNC, t_allocator_pair< KEY_TYPE, VALUE_TYPE > >,
-                              bip::map< KEY_TYPE, VALUE_TYPE, LESS_FUNC, t_allocator_pair< KEY_TYPE, VALUE_TYPE > >
-                              >::type;
-
    template< typename T >
    using t_deque = typename std::conditional< _ENABLE_STD_ALLOCATOR,
                   std::deque< T, allocator< T > >,
                   bip::deque< T, allocator< T > >
                   >::type;
-
-   template< typename T, typename LESS_FUNC >
-   using t_set = typename std::conditional< _ENABLE_STD_ALLOCATOR,
-                  std::set< T, LESS_FUNC, allocator< T > >,
-                  bip::set< T, LESS_FUNC, allocator< T >  >
-                  >::type;
-
 }

--- a/libraries/chainbase/include/chainbase/util/object_id.hpp
+++ b/libraries/chainbase/include/chainbase/util/object_id.hpp
@@ -1,8 +1,7 @@
-#ifndef __OBJECT_ID_HPP
-#define __OBJECT_ID_HPP
+#pragma once
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 namespace chainbase
 {
@@ -31,5 +30,3 @@ public:
 };
 
 } /// namespace chainbase
-
-#endif /// __OBJECT_ID_HPP

--- a/libraries/plugins/account_by_key/account_by_key_plugin.cpp
+++ b/libraries/plugins/account_by_key/account_by_key_plugin.cpp
@@ -1,3 +1,6 @@
+
+#include <steem/chain/steem_fwd.hpp>
+
 #include <steem/plugins/account_by_key/account_by_key_plugin.hpp>
 #include <steem/plugins/account_by_key/account_by_key_objects.hpp>
 

--- a/libraries/plugins/account_history_rocksdb/account_history_rocksdb_plugin.cpp
+++ b/libraries/plugins/account_history_rocksdb/account_history_rocksdb_plugin.cpp
@@ -1,3 +1,6 @@
+
+#include <steem/chain/steem_fwd.hpp>
+
 #include <steem/plugins/account_history_rocksdb/account_history_rocksdb_plugin.hpp>
 
 #include <steem/chain/database.hpp>

--- a/libraries/plugins/block_log_info/block_log_info_plugin.cpp
+++ b/libraries/plugins/block_log_info/block_log_info_plugin.cpp
@@ -1,3 +1,6 @@
+
+#include <steem/chain/steem_fwd.hpp>
+
 #include <steem/plugins/block_log_info/block_log_info_plugin.hpp>
 #include <steem/plugins/block_log_info/block_log_info_objects.hpp>
 

--- a/libraries/plugins/follow/follow_plugin.cpp
+++ b/libraries/plugins/follow/follow_plugin.cpp
@@ -1,3 +1,6 @@
+
+#include <steem/chain/steem_fwd.hpp>
+
 #include <steem/plugins/follow/follow_plugin.hpp>
 #include <steem/plugins/follow/follow_objects.hpp>
 #include <steem/plugins/follow/follow_operations.hpp>

--- a/libraries/plugins/market_history/market_history_plugin.cpp
+++ b/libraries/plugins/market_history/market_history_plugin.cpp
@@ -1,3 +1,6 @@
+
+#include <steem/chain/steem_fwd.hpp>
+
 #include <steem/plugins/market_history/market_history_plugin.hpp>
 
 #include <steem/chain/database.hpp>

--- a/libraries/plugins/rc/rc_plugin.cpp
+++ b/libraries/plugins/rc/rc_plugin.cpp
@@ -1,4 +1,6 @@
 
+#include <steem/chain/steem_fwd.hpp>
+
 #include <steem/plugins/block_data_export/block_data_export_plugin.hpp>
 
 #include <steem/plugins/rc/rc_curve.hpp>

--- a/libraries/plugins/reputation/reputation_plugin.cpp
+++ b/libraries/plugins/reputation/reputation_plugin.cpp
@@ -1,3 +1,6 @@
+
+#include <steem/chain/steem_fwd.hpp>
+
 #include <steem/plugins/reputation/reputation_plugin.hpp>
 #include <steem/plugins/reputation/reputation_objects.hpp>
 

--- a/libraries/plugins/tags/tags_plugin.cpp
+++ b/libraries/plugins/tags/tags_plugin.cpp
@@ -1,3 +1,6 @@
+
+#include <steem/chain/steem_fwd.hpp>
+
 #include <steem/plugins/tags/tags_plugin.hpp>
 
 #include <steem/protocol/config.hpp>

--- a/libraries/plugins/transaction_status/transaction_status_plugin.cpp
+++ b/libraries/plugins/transaction_status/transaction_status_plugin.cpp
@@ -1,3 +1,6 @@
+
+#include <steem/chain/steem_fwd.hpp>
+
 #include <steem/plugins/transaction_status/transaction_status_plugin.hpp>
 #include <steem/plugins/transaction_status/transaction_status_objects.hpp>
 #include <steem/chain/database.hpp>


### PR DESCRIPTION

In order to get this to compile:

- I did some minor cleanup of the `chainbase` code (adding a missing `#include`, fixing whitespace, changing from C style to C++ style include guards)
- Add a header specifically for forward declaration of custom FC serializations implemented by Steem, and move all serializers to it.  FC serialization is very picky about declaration order.
- Implement custom serializers for `bip::flat_map`, `bip::deque` and `shared_string`.  (Not strictly necessary, but this PR is a subset of my integration branch for #3084 which does need them.  Extracting these new serializers into a separate PR would be more trouble than it's worth).
