### PR TITLE
Fix int_array from_variant

### DIFF
--- a/libraries/chain/include/steem/chain/hardfork_property_object.hpp
+++ b/libraries/chain/include/steem/chain/hardfork_property_object.hpp
@@ -32,7 +32,7 @@ namespace steem { namespace chain {
    typedef multi_index_container<
       hardfork_property_object,
       indexed_by<
-         ordered_unique< member< hardfork_property_object, hardfork_property_object::id_type, &hardfork_property_object::id > >
+         ordered_unique< tag< by_id >, member< hardfork_property_object, hardfork_property_object::id_type, &hardfork_property_object::id > >
       >,
       allocator< hardfork_property_object >
    > hardfork_property_index;

--- a/libraries/fc/include/fc/int_array.hpp
+++ b/libraries/fc/include/fc/int_array.hpp
@@ -52,18 +52,7 @@ void from_variant( const variant& var, fc::int_array<T,N>& a )
 
    for( size_t i=0; i<N; i++ )
    {
-      if( std::numeric_limits<T>::is_signed )
-      {
-         int64_t temp = varray[i].as_int64();
-         FC_ASSERT( (temp >= std::numeric_limits<T>::min()) && (temp <= std::numeric_limits<T>::max()) );
-         a[i] = temp;
-      }
-      else
-      {
-         uint64_t temp = varray[i].as_uint64();
-         FC_ASSERT( temp <= std::numeric_limits<T>::max() );
-         a[i] = temp;
-      }
+      from_variant( varray[i], a[i] );
    }
 }
 

--- a/libraries/plugins/reputation/include/steem/plugins/reputation/reputation_objects.hpp
+++ b/libraries/plugins/reputation/include/steem/plugins/reputation/reputation_objects.hpp
@@ -3,6 +3,10 @@
 
 #include <boost/multi_index/composite_key.hpp>
 
+namespace steem { namespace chain {
+struct by_account;
+} }
+
 namespace steem { namespace plugins { namespace reputation {
 
 using namespace std;
@@ -39,10 +43,6 @@ class reputation_object : public object< reputation_object_type, reputation_obje
 
 typedef oid< reputation_object > reputation_id_type;
 
-
-struct by_id;
-struct by_account;
-
 typedef multi_index_container<
    reputation_object,
    indexed_by<
@@ -51,7 +51,6 @@ typedef multi_index_container<
    >,
    allocator< reputation_object >
 > reputation_index;
-
 
 } } } // steem::plugins::reputation
 


### PR DESCRIPTION
PR for #3123.

This also includes a couple tiny commits from the #3084 integration branch, namely, fixing a couple objects that didn't use the correct paradigm for multi-index container tag structs.

Specifically:

- `hardfork_property_object` had an anonymous index rather than `by_id`
- `steem::plugins::reputation` created its own `by_id` and `by_account` structs, rather than using the ones in `steem::chain`
