### PR TITLE
Grab head_block_time and head_block_number in visitor constructor

### DIFF
--- a/libraries/plugins/rc/rc_plugin.cpp
+++ b/libraries/plugins/rc/rc_plugin.cpp
@@ -571,7 +571,11 @@ struct pre_apply_operation_visitor
    rc_plugin_skip_flags                     _skip;
 
    pre_apply_operation_visitor( database& db ) : _db(db)
-   {}
+   {
+      const auto& gpo = _db.get_dynamic_global_properties();
+      _current_time = gpo.time.sec_since_epoch();
+      _current_block_number = gpo.head_block_number;
+   }
 
    void regenerate( const account_object& account, const rc_account_object& rc_account )const
    {


### PR DESCRIPTION
In #2719 I had done a few refactors during development that got squashed in the PR. One change was only partially reverted. This adds back the correct behavior.