### PR TITLE
Closes #3149 - Update Exchange Example Config File

### DIFF
--- a/doc/example_config.ini
+++ b/doc/example_config.ini
@@ -108,7 +108,7 @@ market-history-buckets-per-size = 5760
 # seed-node =
 
 # The IP address and port of a remote peer to sync with.
-p2p-seed-node = seed-east.steemit.com:2001 seed-central.steemit.com:2001 seed-west.steemit.com:2001 steem-seed1.abit-more.com:2001 52.74.152.79:2001 seed.steemd.com:34191 anyx.co:2001 seed.xeldal.com:12150 seed.steemnodes.com:2001 seed.liondani.com:2016 gtg.steem.house:2001 seed.jesta.us:2001 steemd.pharesim.me:2001 5.9.18.213:2001 lafonasteem.com:2001 seed.rossco99.com:2001 steem-seed.altcap.io:40696 seed.roelandp.nl:2001 steem.global:2001 seed.esteem.ws:2001 seed.timcliff.com:2001 104.199.118.92:2001 seed.steemviz.com:2001 steem-seed.lukestokes.info:2001 seed.steemian.info:2001 seed.followbtcnews.com:2001 node.mahdiyari.info:2001 seed.curiesteem.com:2001 seed.riversteem.com:2001 148.251.237.104:2001 seed1.blockbrothers.io:2001 steemseed-fin.privex.io:2001 seed.jamzed.pl:2001 seed1.cryptobot.news:2001 seed.thecryptodrive.com:2001 seed.brandonfrye.us:2001 seed.firepower.ltd:2001
+# p2p-seed-node =
 
 # P2P network parameters. (Default: {"listen_endpoint":"0.0.0.0:0","accept_incoming_connections":true,"wait_if_endpoint_is_busy":true,"private_key":"0000000000000000000000000000000000000000000000000000000000000000","desired_number_of_connections":20,"maximum_number_of_connections":200,"peer_connection_retry_timeout":30,"peer_inactivity_timeout":5,"peer_advertising_disabled":false,"maximum_number_of_blocks_to_handle_at_one_time":200,"maximum_number_of_sync_blocks_to_prefetch":2000,"maximum_blocks_per_peer_during_syncing":200,"active_ignored_request_timeout_microseconds":6000000} )
 # p2p-parameters =
@@ -138,10 +138,10 @@ tags-start-promoted = 0
 tags-skip-startup-update = 0
 
 # Local http endpoint for webserver requests.
-webserver-http-endpoint = 0.0.0.0:8090
+webserver-http-endpoint = 127.0.0.1:8090
 
 # Local websocket endpoint for webserver requests.
-webserver-ws-endpoint = 0.0.0.0:8090
+webserver-ws-endpoint = 127.0.0.1:8090
 
 # Local http and websocket endpoint for webserver requests. Deprecated in favor of webserver-http-endpoint and webserver-ws-endpoint
 # rpc-endpoint =

--- a/doc/example_config.ini
+++ b/doc/example_config.ini
@@ -1,115 +1,165 @@
-# this will need to increase depending on which plugins/apis you use
-# 54 GB should be sufficient for a consensus node
+# Appender definition json: {"appender", "stream", "file"} Can only specify a file OR a stream
+log-appender = {"appender":"stderr","stream":"std_error"} {"appender":"p2p","file":"logs/p2p/p2p.log"}
+
+# log-console-appender =
+
+# log-file-appender =
+
+# Logger definition json: {"name", "level", "appender"}
+log-logger = {"name":"default","level":"info","appender":"stderr"} {"name":"p2p","level":"warn","appender":"p2p"}
+
+# Whether to print backtrace on SIGSEGV
+backtrace = yes
+
+# Plugin(s) to enable, may be specified multiple times
+plugin = witness account_history_rocksdb account_history_api
+
+# Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times.
+account-history-track-account-range = ["exchange_account", "exchange_account"]
+
+# Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times. Deprecated in favor of account-history-track-account-range.
+# track-account-range =
+
+# Defines a list of operations which will be explicitly logged.
+# account-history-whitelist-ops =
+
+# Defines a list of operations which will be explicitly logged. Deprecated in favor of account-history-whitelist-ops.
+# history-whitelist-ops =
+
+# Defines a list of operations which will be explicitly ignored.
+# account-history-blacklist-ops =
+
+# Defines a list of operations which will be explicitly ignored. Deprecated in favor of account-history-blacklist-ops.
+# history-blacklist-ops =
+
+# Disables automatic account history trimming
+history-disable-pruning = 0
+
+# The location of the rocksdb database for account history. By default it is $DATA_DIR/blockchain/account-history-rocksdb-storage
+account-history-rocksdb-path = "blockchain/account-history-rocksdb-storage"
+
+# Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times.
+# account-history-rocksdb-track-account-range =
+
+# Defines a list of operations which will be explicitly logged.
+# account-history-rocksdb-whitelist-ops =
+
+# Defines a list of operations which will be explicitly ignored.
+# account-history-rocksdb-blacklist-ops =
+
+# Where to export data (NONE to discard)
+block-data-export-file = NONE
+
+# How often to print out block_log_info (default 1 day)
+block-log-info-print-interval-seconds = 86400
+
+# Whether to defer printing until block is irreversible
+block-log-info-print-irreversible = 1
+
+# Where to print (filename or special sink ILOG, STDOUT, STDERR)
+block-log-info-print-file = ILOG
+
+# the location of the chain shared memory files (absolute path or relative to application data dir)
+shared-file-dir = "blockchain"
+
+# Size of the shared memory file. Default: 54G. If running a full node, increase this value to 200G.
 shared-file-size = 54G
 
-# Endpoint for P2P node to listen on
-# p2p-endpoint =
+# A 2 precision percentage (0-10000) that defines the threshold for when to autoscale the shared memory file. Setting this to 0 disables autoscaling. Recommended value for consensus node is 9500 (95%). Full node is 9900 (99%)
+shared-file-full-threshold = 0
 
-# Maxmimum number of incoming connections on P2P endpoint
-# p2p-max-connections =
-
-# P2P nodes to connect to on startup (may specify multiple times)
-# seed-node =
+# A 2 precision percentage (0-10000) that defines how quickly to scale the shared memory file. When autoscaling occurs the file's size will be increased by this percent. Setting this to 0 disables autoscaling. Recommended value is between 1000-2000 (10-20%)
+shared-file-scale-rate = 0
 
 # Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.
 # checkpoint =
 
-# Endpoint for websocket RPC to listen on
-# rpc-endpoint =
-
-# Endpoint for TLS websocket RPC to listen on
-# rpc-tls-endpoint =
-
-# The TLS certificate file for this server
-# server-pem =
-
-# Password for this certificate
-# server-pem-password =
-
-# Block signing key to use for init witnesses, overrides genesis file
-# dbg-init-key =
-
-# API user specification, may be specified multiple times
-# api-user =
-
-# Set an API to be publicly available, may be specified multiple times
-public-api = database_api login_api
-
-# Plugin(s) to enable, may be specified multiple times
-enable-plugin = account_history
-
-# JSON list of [nblocks,nseconds] pairs, see doc/bcd-trigger.md
-bcd-trigger = [[0,10],[85,300]]
-
-# Defines a range of accounts to track as a json pair ["from","to"] [from,to]
-track-account-range = ["exchange_account", "exchange_account"]
-
-# Ignore posting operations, only track transfers and account updates
-# filter-posting-ops =
+# flush shared memory changes to disk every N blocks
+# flush-state-interval =
 
 # Database edits to apply on startup (may specify multiple times)
+# debug-node-edit-script =
+
+# Database edits to apply on startup (may specify multiple times). Deprecated in favor of debug-node-edit-script.
 # edit-script =
 
-# RPC endpoint of a trusted validating node (required)
-# trusted-node =
-
 # Set the maximum size of cached feed for an account
-# follow-max-feed-size = 500
+follow-max-feed-size = 500
+
+# Block time (in epoch seconds) when to start calculating feeds
+follow-start-feeds = 0
+
+# json-rpc log directory name.
+# log-json-rpc =
 
 # Track market history by grouping orders into buckets of equal size measured in seconds specified as a JSON array of numbers
-# bucket-size = [15,60,300,3600,86400]
+market-history-bucket-size = [15,60,300,3600,86400]
 
 # How far back in time to track history for each bucket size, measured in the number of buckets (default: 5760)
-# history-per-size = 5760
+market-history-buckets-per-size = 5760
 
-# Defines a range of accounts to private messages to/from as a json pair ["from","to"] [from,to)
-# pm-account-range =
+# The local IP address and port to listen for incoming connections.
+# p2p-endpoint =
+
+# Maxmimum number of incoming connections on P2P endpoint.
+# p2p-max-connections =
+
+# The IP address and port of a remote peer to sync with. Deprecated in favor of p2p-seed-node.
+# seed-node =
+
+# The IP address and port of a remote peer to sync with.
+p2p-seed-node = seed-east.steemit.com:2001 seed-central.steemit.com:2001 seed-west.steemit.com:2001 steem-seed1.abit-more.com:2001 52.74.152.79:2001 seed.steemd.com:34191 anyx.co:2001 seed.xeldal.com:12150 seed.steemnodes.com:2001 seed.liondani.com:2016 gtg.steem.house:2001 seed.jesta.us:2001 steemd.pharesim.me:2001 5.9.18.213:2001 lafonasteem.com:2001 seed.rossco99.com:2001 steem-seed.altcap.io:40696 seed.roelandp.nl:2001 steem.global:2001 seed.esteem.ws:2001 seed.timcliff.com:2001 104.199.118.92:2001 seed.steemviz.com:2001 steem-seed.lukestokes.info:2001 seed.steemian.info:2001 seed.followbtcnews.com:2001 node.mahdiyari.info:2001 seed.curiesteem.com:2001 seed.riversteem.com:2001 148.251.237.104:2001 seed1.blockbrothers.io:2001 steemseed-fin.privex.io:2001 seed.jamzed.pl:2001 seed1.cryptobot.news:2001 seed.thecryptodrive.com:2001 seed.brandonfrye.us:2001 seed.firepower.ltd:2001
+
+# P2P network parameters. (Default: {"listen_endpoint":"0.0.0.0:0","accept_incoming_connections":true,"wait_if_endpoint_is_busy":true,"private_key":"0000000000000000000000000000000000000000000000000000000000000000","desired_number_of_connections":20,"maximum_number_of_connections":200,"peer_connection_retry_timeout":30,"peer_inactivity_timeout":5,"peer_advertising_disabled":false,"maximum_number_of_blocks_to_handle_at_one_time":200,"maximum_number_of_sync_blocks_to_prefetch":2000,"maximum_blocks_per_peer_during_syncing":200,"active_ignored_request_timeout_microseconds":6000000} )
+# p2p-parameters =
+
+# Skip rejecting transactions when account has insufficient RCs. This is not recommended.
+rc-skip-reject-not-enough-rc = 0
+
+# Generate historical resource credits
+rc-compute-historical-rc = 0
+
+# Endpoint to send statsd messages to.
+# statsd-endpoint =
+
+# Size to batch statsd messages.
+statsd-batchsize = 1
+
+# Whitelist of statistics to capture.
+# statsd-whitelist =
+
+# Blacklist of statistics to capture.
+# statsd-blacklist =
+
+# Block time (in epoch seconds) when to start calculating promoted content. Should be 1 week prior to current time.
+tags-start-promoted = 0
+
+# Skip updating tags on startup. Can safely be skipped when starting a previously running node. Should not be skipped when reindexing.
+tags-skip-startup-update = 0
+
+# Local http endpoint for webserver requests.
+webserver-http-endpoint = 0.0.0.0:8090
+
+# Local websocket endpoint for webserver requests.
+webserver-ws-endpoint = 0.0.0.0:8090
+
+# Local http and websocket endpoint for webserver requests. Deprecated in favor of webserver-http-endpoint and webserver-ws-endpoint
+# rpc-endpoint =
+
+# Number of threads used to handle queries. Default: 32.
+webserver-thread-pool-size = 32
 
 # Enable block production, even if the chain is stale.
-# enable-stale-production = false
+enable-stale-production = 0
 
 # Percent of witnesses (0-99) that must be participating in order to produce blocks
-# required-participation = false
+required-participation = 33
 
 # name of witness controlled by this node (e.g. initwitness )
 # witness =
 
-# name of miner and its private key (e.g. ["account","WIF PRIVATE KEY"] )
-# miner =
-
-# Number of threads to use for proof of work mining
-# mining-threads =
-
 # WIF PRIVATE KEY to be used by one or more witnesses or miners
 # private-key =
 
-# Account creation fee to be voted on upon successful POW - Minimum fee is 100.000 STEEM (written as 100000)
-# miner-account-creation-fee =
-
-# Maximum block size (in bytes) to be voted on upon successful POW - Max block size must be between 128 KB and 750 MB
-# miner-maximum-block-size =
-
-# SBD interest rate to be vote on upon successful POW - Default interest rate is 10% (written as 1000)
-# miner-sbd-interest-rate =
-
-# declare an appender named "stderr" that writes messages to the console
-[log.console_appender.stderr]
-stream=std_error
-
-# declare an appender named "p2p" that writes messages to p2p.log
-[log.file_appender.p2p]
-filename=logs/p2p/p2p.log
-# filename can be absolute or relative to this config file
-
-# route any messages logged to the default logger to the "stderr" logger we
-# declared above, if they are info level are higher
-[logger.default]
-level=info
-appenders=stderr
-
-# route messages sent to the "p2p" logger to stderr too
-[logger.p2p]
-level=info
-appenders=stderr
-
-
+# Skip enforcing bandwidth restrictions. Default is true in favor of rc_plugin.
+witness-skip-enforce-bandwidth = 1


### PR DESCRIPTION
This PR replaces the exchange example config file with an updated version.
- It uses the default config file that is created from a fresh default steemd installation as the starting point.
- It sets the enabled plugins to: `witness account_history_rocksdb account_history_api`
- It adds an example `account-history-track-account-range`
- It enables `webserver-http-endpoint` and `webserver-ws-endpoint`