### PR TITLE
Closes #3149 - Update Exchange Example Config File

### DIFF
--- a/doc/example_config.ini
+++ b/doc/example_config.ini
@@ -1,9 +1,9 @@
 # Appender definition json: {"appender", "stream", "file"} Can only specify a file OR a stream
 log-appender = {"appender":"stderr","stream":"std_error"} {"appender":"p2p","file":"logs/p2p/p2p.log"}
 
-# log-console-appender =
+# log-console-appender = 
 
-# log-file-appender =
+# log-file-appender = 
 
 # Logger definition json: {"name", "level", "appender"}
 log-logger = {"name":"default","level":"info","appender":"stderr"} {"name":"p2p","level":"warn","appender":"p2p"}
@@ -18,19 +18,19 @@ plugin = witness account_history_rocksdb account_history_api
 account-history-track-account-range = ["exchange_account", "exchange_account"]
 
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times. Deprecated in favor of account-history-track-account-range.
-# track-account-range =
+# track-account-range = 
 
 # Defines a list of operations which will be explicitly logged.
-# account-history-whitelist-ops =
+# account-history-whitelist-ops = 
 
 # Defines a list of operations which will be explicitly logged. Deprecated in favor of account-history-whitelist-ops.
-# history-whitelist-ops =
+# history-whitelist-ops = 
 
 # Defines a list of operations which will be explicitly ignored.
-# account-history-blacklist-ops =
+# account-history-blacklist-ops = 
 
 # Defines a list of operations which will be explicitly ignored. Deprecated in favor of account-history-blacklist-ops.
-# history-blacklist-ops =
+# history-blacklist-ops = 
 
 # Disables automatic account history trimming
 history-disable-pruning = 0
@@ -39,13 +39,13 @@ history-disable-pruning = 0
 account-history-rocksdb-path = "blockchain/account-history-rocksdb-storage"
 
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times.
-# account-history-rocksdb-track-account-range =
+# account-history-rocksdb-track-account-range = 
 
 # Defines a list of operations which will be explicitly logged.
-# account-history-rocksdb-whitelist-ops =
+# account-history-rocksdb-whitelist-ops = 
 
 # Defines a list of operations which will be explicitly ignored.
-# account-history-rocksdb-blacklist-ops =
+# account-history-rocksdb-blacklist-ops = 
 
 # Where to export data (NONE to discard)
 block-data-export-file = NONE
@@ -72,16 +72,16 @@ shared-file-full-threshold = 0
 shared-file-scale-rate = 0
 
 # Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.
-# checkpoint =
+# checkpoint = 
 
 # flush shared memory changes to disk every N blocks
-# flush-state-interval =
+# flush-state-interval = 
 
 # Database edits to apply on startup (may specify multiple times)
-# debug-node-edit-script =
+# debug-node-edit-script = 
 
 # Database edits to apply on startup (may specify multiple times). Deprecated in favor of debug-node-edit-script.
-# edit-script =
+# edit-script = 
 
 # Set the maximum size of cached feed for an account
 follow-max-feed-size = 500
@@ -90,7 +90,7 @@ follow-max-feed-size = 500
 follow-start-feeds = 0
 
 # json-rpc log directory name.
-# log-json-rpc =
+# log-json-rpc = 
 
 # Track market history by grouping orders into buckets of equal size measured in seconds specified as a JSON array of numbers
 market-history-bucket-size = [15,60,300,3600,86400]
@@ -99,19 +99,19 @@ market-history-bucket-size = [15,60,300,3600,86400]
 market-history-buckets-per-size = 5760
 
 # The local IP address and port to listen for incoming connections.
-# p2p-endpoint =
+# p2p-endpoint = 
 
 # Maxmimum number of incoming connections on P2P endpoint.
-# p2p-max-connections =
+# p2p-max-connections = 
 
 # The IP address and port of a remote peer to sync with. Deprecated in favor of p2p-seed-node.
-# seed-node =
+# seed-node = 
 
 # The IP address and port of a remote peer to sync with.
-# p2p-seed-node =
+# p2p-seed-node = 
 
 # P2P network parameters. (Default: {"listen_endpoint":"0.0.0.0:0","accept_incoming_connections":true,"wait_if_endpoint_is_busy":true,"private_key":"0000000000000000000000000000000000000000000000000000000000000000","desired_number_of_connections":20,"maximum_number_of_connections":200,"peer_connection_retry_timeout":30,"peer_inactivity_timeout":5,"peer_advertising_disabled":false,"maximum_number_of_blocks_to_handle_at_one_time":200,"maximum_number_of_sync_blocks_to_prefetch":2000,"maximum_blocks_per_peer_during_syncing":200,"active_ignored_request_timeout_microseconds":6000000} )
-# p2p-parameters =
+# p2p-parameters = 
 
 # Skip rejecting transactions when account has insufficient RCs. This is not recommended.
 rc-skip-reject-not-enough-rc = 0
@@ -120,16 +120,16 @@ rc-skip-reject-not-enough-rc = 0
 rc-compute-historical-rc = 0
 
 # Endpoint to send statsd messages to.
-# statsd-endpoint =
+# statsd-endpoint = 
 
 # Size to batch statsd messages.
 statsd-batchsize = 1
 
 # Whitelist of statistics to capture.
-# statsd-whitelist =
+# statsd-whitelist = 
 
 # Blacklist of statistics to capture.
-# statsd-blacklist =
+# statsd-blacklist = 
 
 # Block time (in epoch seconds) when to start calculating promoted content. Should be 1 week prior to current time.
 tags-start-promoted = 0
@@ -144,7 +144,7 @@ webserver-http-endpoint = 127.0.0.1:8090
 webserver-ws-endpoint = 127.0.0.1:8090
 
 # Local http and websocket endpoint for webserver requests. Deprecated in favor of webserver-http-endpoint and webserver-ws-endpoint
-# rpc-endpoint =
+# rpc-endpoint = 
 
 # Number of threads used to handle queries. Default: 32.
 webserver-thread-pool-size = 32
@@ -156,10 +156,10 @@ enable-stale-production = 0
 required-participation = 33
 
 # name of witness controlled by this node (e.g. initwitness )
-# witness =
+# witness = 
 
 # WIF PRIVATE KEY to be used by one or more witnesses or miners
-# private-key =
+# private-key = 
 
 # Skip enforcing bandwidth restrictions. Default is true in favor of rc_plugin.
 witness-skip-enforce-bandwidth = 1

--- a/doc/example_config.ini
+++ b/doc/example_config.ini
@@ -11,13 +11,10 @@ backtrace = yes
 plugin = witness account_history_rocksdb account_history_api
 
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times.
-account-history-track-account-range = ["exchange_account", "exchange_account"]
+account-history-rocksdb-track-account-range = ["exchange_account", "exchange_account"]
 
 # The location of the rocksdb database for account history. By default it is $DATA_DIR/blockchain/account-history-rocksdb-storage
 account-history-rocksdb-path = "blockchain/account-history-rocksdb-storage"
-
-# Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times.
-# account-history-rocksdb-track-account-range = 
 
 # the location of the chain shared memory files (absolute path or relative to application data dir)
 shared-file-dir = "blockchain"

--- a/doc/example_config.ini
+++ b/doc/example_config.ini
@@ -9,6 +9,8 @@ backtrace = yes
 
 # Plugin(s) to enable, may be specified multiple times
 plugin = witness account_history_rocksdb account_history_api
+plugin = database_api condenser_api network_broadcast_api
+plugin = account_by_key account_by_key_api
 
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times.
 account-history-rocksdb-track-account-range = ["exchange_account", "exchange_account"]

--- a/doc/example_config.ini
+++ b/doc/example_config.ini
@@ -23,10 +23,10 @@ shared-file-dir = "blockchain"
 shared-file-size = 54G
 
 # A 2 precision percentage (0-10000) that defines the threshold for when to autoscale the shared memory file. Setting this to 0 disables autoscaling. Recommended value for consensus node is 9500 (95%). Full node is 9900 (99%)
-shared-file-full-threshold = 0
+# shared-file-full-threshold = 9800
 
 # A 2 precision percentage (0-10000) that defines how quickly to scale the shared memory file. When autoscaling occurs the file's size will be increased by this percent. Setting this to 0 disables autoscaling. Recommended value is between 1000-2000 (10-20%)
-shared-file-scale-rate = 0
+# shared-file-scale-rate = 500
 
 # The IP address and port of a remote peer to sync with.
 # p2p-seed-node = 

--- a/doc/example_config.ini
+++ b/doc/example_config.ini
@@ -1,10 +1,6 @@
 # Appender definition json: {"appender", "stream", "file"} Can only specify a file OR a stream
 log-appender = {"appender":"stderr","stream":"std_error"} {"appender":"p2p","file":"logs/p2p/p2p.log"}
 
-# log-console-appender = 
-
-# log-file-appender = 
-
 # Logger definition json: {"name", "level", "appender"}
 log-logger = {"name":"default","level":"info","appender":"stderr"} {"name":"p2p","level":"warn","appender":"p2p"}
 
@@ -17,47 +13,11 @@ plugin = witness account_history_rocksdb account_history_api
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times.
 account-history-track-account-range = ["exchange_account", "exchange_account"]
 
-# Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times. Deprecated in favor of account-history-track-account-range.
-# track-account-range = 
-
-# Defines a list of operations which will be explicitly logged.
-# account-history-whitelist-ops = 
-
-# Defines a list of operations which will be explicitly logged. Deprecated in favor of account-history-whitelist-ops.
-# history-whitelist-ops = 
-
-# Defines a list of operations which will be explicitly ignored.
-# account-history-blacklist-ops = 
-
-# Defines a list of operations which will be explicitly ignored. Deprecated in favor of account-history-blacklist-ops.
-# history-blacklist-ops = 
-
-# Disables automatic account history trimming
-history-disable-pruning = 0
-
 # The location of the rocksdb database for account history. By default it is $DATA_DIR/blockchain/account-history-rocksdb-storage
 account-history-rocksdb-path = "blockchain/account-history-rocksdb-storage"
 
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times.
 # account-history-rocksdb-track-account-range = 
-
-# Defines a list of operations which will be explicitly logged.
-# account-history-rocksdb-whitelist-ops = 
-
-# Defines a list of operations which will be explicitly ignored.
-# account-history-rocksdb-blacklist-ops = 
-
-# Where to export data (NONE to discard)
-block-data-export-file = NONE
-
-# How often to print out block_log_info (default 1 day)
-block-log-info-print-interval-seconds = 86400
-
-# Whether to defer printing until block is irreversible
-block-log-info-print-irreversible = 1
-
-# Where to print (filename or special sink ILOG, STDOUT, STDERR)
-block-log-info-print-file = ILOG
 
 # the location of the chain shared memory files (absolute path or relative to application data dir)
 shared-file-dir = "blockchain"
@@ -71,50 +31,11 @@ shared-file-full-threshold = 0
 # A 2 precision percentage (0-10000) that defines how quickly to scale the shared memory file. When autoscaling occurs the file's size will be increased by this percent. Setting this to 0 disables autoscaling. Recommended value is between 1000-2000 (10-20%)
 shared-file-scale-rate = 0
 
-# Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.
-# checkpoint = 
-
-# flush shared memory changes to disk every N blocks
-# flush-state-interval = 
-
-# Database edits to apply on startup (may specify multiple times)
-# debug-node-edit-script = 
-
-# Database edits to apply on startup (may specify multiple times). Deprecated in favor of debug-node-edit-script.
-# edit-script = 
-
-# json-rpc log directory name.
-# log-json-rpc = 
-
-# The local IP address and port to listen for incoming connections.
-# p2p-endpoint = 
-
-# Maxmimum number of incoming connections on P2P endpoint.
-# p2p-max-connections = 
-
-# The IP address and port of a remote peer to sync with. Deprecated in favor of p2p-seed-node.
-# seed-node = 
-
 # The IP address and port of a remote peer to sync with.
 # p2p-seed-node = 
-
-# P2P network parameters. (Default: {"listen_endpoint":"0.0.0.0:0","accept_incoming_connections":true,"wait_if_endpoint_is_busy":true,"private_key":"0000000000000000000000000000000000000000000000000000000000000000","desired_number_of_connections":20,"maximum_number_of_connections":200,"peer_connection_retry_timeout":30,"peer_inactivity_timeout":5,"peer_advertising_disabled":false,"maximum_number_of_blocks_to_handle_at_one_time":200,"maximum_number_of_sync_blocks_to_prefetch":2000,"maximum_blocks_per_peer_during_syncing":200,"active_ignored_request_timeout_microseconds":6000000} )
-# p2p-parameters = 
-
-# Skip rejecting transactions when account has insufficient RCs. This is not recommended.
-rc-skip-reject-not-enough-rc = 0
-
-# Generate historical resource credits
-rc-compute-historical-rc = 0
 
 # Local http endpoint for webserver requests.
 webserver-http-endpoint = 127.0.0.1:8090
 
 # Local websocket endpoint for webserver requests.
 webserver-ws-endpoint = 127.0.0.1:8090
-
-# Local http and websocket endpoint for webserver requests. Deprecated in favor of webserver-http-endpoint and webserver-ws-endpoint
-# rpc-endpoint = 
-
-# Number of threads used to handle queries. Default: 32.
-webserver-thread-pool-size = 32

--- a/doc/example_config.ini
+++ b/doc/example_config.ini
@@ -83,20 +83,8 @@ shared-file-scale-rate = 0
 # Database edits to apply on startup (may specify multiple times). Deprecated in favor of debug-node-edit-script.
 # edit-script = 
 
-# Set the maximum size of cached feed for an account
-follow-max-feed-size = 500
-
-# Block time (in epoch seconds) when to start calculating feeds
-follow-start-feeds = 0
-
 # json-rpc log directory name.
 # log-json-rpc = 
-
-# Track market history by grouping orders into buckets of equal size measured in seconds specified as a JSON array of numbers
-market-history-bucket-size = [15,60,300,3600,86400]
-
-# How far back in time to track history for each bucket size, measured in the number of buckets (default: 5760)
-market-history-buckets-per-size = 5760
 
 # The local IP address and port to listen for incoming connections.
 # p2p-endpoint = 
@@ -119,24 +107,6 @@ rc-skip-reject-not-enough-rc = 0
 # Generate historical resource credits
 rc-compute-historical-rc = 0
 
-# Endpoint to send statsd messages to.
-# statsd-endpoint = 
-
-# Size to batch statsd messages.
-statsd-batchsize = 1
-
-# Whitelist of statistics to capture.
-# statsd-whitelist = 
-
-# Blacklist of statistics to capture.
-# statsd-blacklist = 
-
-# Block time (in epoch seconds) when to start calculating promoted content. Should be 1 week prior to current time.
-tags-start-promoted = 0
-
-# Skip updating tags on startup. Can safely be skipped when starting a previously running node. Should not be skipped when reindexing.
-tags-skip-startup-update = 0
-
 # Local http endpoint for webserver requests.
 webserver-http-endpoint = 127.0.0.1:8090
 
@@ -148,18 +118,3 @@ webserver-ws-endpoint = 127.0.0.1:8090
 
 # Number of threads used to handle queries. Default: 32.
 webserver-thread-pool-size = 32
-
-# Enable block production, even if the chain is stale.
-enable-stale-production = 0
-
-# Percent of witnesses (0-99) that must be participating in order to produce blocks
-required-participation = 33
-
-# name of witness controlled by this node (e.g. initwitness )
-# witness = 
-
-# WIF PRIVATE KEY to be used by one or more witnesses or miners
-# private-key = 
-
-# Skip enforcing bandwidth restrictions. Default is true in favor of rc_plugin.
-witness-skip-enforce-bandwidth = 1


### PR DESCRIPTION
Closes #3149

Local PR for #3167

> This PR replaces the exchange example config file with an updated version.
> 
> - It uses the default config file that is created from a fresh default steemd installation as the starting point.
> - It sets the enabled plugins to: `witness account_history_rocksdb account_history_api`
> - It adds an example `account-history-track-account-range`
> - It enables `webserver-http-endpoint` and `webserver-ws-endpoint`