### PR TITLE
Update domain for anyx

### DIFF
--- a/doc/seednodes.txt
+++ b/doc/seednodes.txt
@@ -4,7 +4,7 @@ seed-west.steemit.com:2001          # steemit
 steem-seed1.abit-more.com:2001      # abit
 52.74.152.79:2001                   # smooth.witness
 seed.steemd.com:34191               # roadscape
-anyx.co:2001                        # anyx
+anyx.io:2001                        # anyx
 seed.xeldal.com:12150               # xeldal
 seed.steemnodes.com:2001            # wackou
 seed.liondani.com:2016              # liondani


### PR DESCRIPTION
`anyx.io` will be the long-term-support domain for steem, and will redirect to full node or p2p seed node based on port. `anyx.co` is deprecated but will continue to work until this change is added to the next version of p2p defaults.