### PR TITLE
Fix version.hpp for newer glibc by adding sysmacros

### DIFF
--- a/libraries/protocol/include/steem/protocol/version.hpp
+++ b/libraries/protocol/include/steem/protocol/version.hpp
@@ -2,6 +2,7 @@
 
 #include <fc/string.hpp>
 #include <fc/time.hpp>
+#include <sys/sysmacros.h>
 
 namespace steem { namespace protocol {
 


### PR DESCRIPTION
When building on Ubuntu 18.04, errors are raised about the use of `minor` and `major` without including `sys/sysmacros.h`

This one line addition of `#include <sys/sysmacros.h>` fixes the steemd build on newer versions of glibc.