### PR TITLE
fix zero voting power

### DIFF
--- a/libraries/plugins/apis/condenser_api/condenser_api.cpp
+++ b/libraries/plugins/apis/condenser_api/condenser_api.cpp
@@ -2082,6 +2082,9 @@ uint16_t api_account_object::_compute_voting_power( const database_api::api_acco
    vp_t2 /= vests;
 
    uint64_t vp_t2u = vp_t2.to_uint64();
+   if( vt_t2u == 0 )
+      return 0;
+
    if( vp_t2u >= STEEM_100_PERCENT )
    {
       wlog( "Truncated vp_t2u to STEEM_100_PERCENT for account ${a}", ("a", a.name) );
@@ -2089,7 +2092,7 @@ uint16_t api_account_object::_compute_voting_power( const database_api::api_acco
    }
    uint16_t vp_t1 = uint16_t( vp_t2u ) - uint16_t( std::min( vp_t2u, vp_dt ) );
 
-   return vp_t1;
+   return vp_t1 ? vp_t1 : a.voting_power;
 }
 
 condenser_api::condenser_api()


### PR DESCRIPTION
Fix #3217 

Currently, a.voting_power of users who haven't voted for more than 5 days but had some financial transaction that affected effective vesting shares (e.g., claim reward, powerup, delegation) is set to 0, which no longer represents the voting power at the a.last_vote_time.

This fix returns the previous a.voting power when this reset happens (unless current_mana is 0, case 2 below).

This fix is safe cause vp_t1 = 0 can occur only in the following two cases:

1) 5 days passed
current voting power (calculated from a.voting_power and a.last_vote_time) will be 100% either way. But this fix is more informative, since it returns the last voting power.

2) vp_t2u = 0
L2085 return 0 (same as before)