### PR TITLE
fix #3237 14 week powerdown

### DIFF
--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -1156,8 +1156,16 @@ void withdraw_vesting_evaluator::do_apply( const withdraw_vesting_operation& o )
       {
          auto new_vesting_withdraw_rate = asset( o.vesting_shares.amount / vesting_withdraw_intervals, VESTS_SYMBOL );
 
-         if( new_vesting_withdraw_rate.amount * vesting_withdraw_intervals < o.vesting_shares.amount )
-            new_vesting_withdraw_rate.amount += 1;
+         if( db.has_hardfork( STEEM_HARDFORK_0_21 ) )
+         {
+            if( new_vesting_withdraw_rate.amount * vesting_withdraw_intervals < o.vesting_shares.amount )
+               new_vesting_withdraw_rate.amount += 1;
+         }
+         else
+         {
+            if( new_vesting_withdraw_rate.amount == 0 )
+               new_vesting_withdraw_rate.amount = 1;         
+         }         
 
          if( _db.has_hardfork( STEEM_HARDFORK_0_5__57 ) )
             FC_ASSERT( account.vesting_withdraw_rate  != new_vesting_withdraw_rate, "This operation would not change the vesting withdraw rate." );

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -1156,8 +1156,8 @@ void withdraw_vesting_evaluator::do_apply( const withdraw_vesting_operation& o )
       {
          auto new_vesting_withdraw_rate = asset( o.vesting_shares.amount / vesting_withdraw_intervals, VESTS_SYMBOL );
 
-         if( new_vesting_withdraw_rate.amount == 0 )
-            new_vesting_withdraw_rate.amount = 1;
+         if( new_vesting_withdraw_rate.amount * vesting_withdraw_intervals < o.vesting_shares.amount )
+            new_vesting_withdraw_rate.amount += 1;
 
          if( _db.has_hardfork( STEEM_HARDFORK_0_5__57 ) )
             FC_ASSERT( account.vesting_withdraw_rate  != new_vesting_withdraw_rate, "This operation would not change the vesting withdraw rate." );


### PR DESCRIPTION
Fix #3237

- Floor -> Ceil
- Combine the zero new_vesting_withdraw_rate case.

Ceiling is fine (i.e., never withdraw more than requested in total) due to here: https://github.com/steemit/steem/blob/7e50f3e1b064c33a2276e64728efb01614a5fb3d/libraries/plugins/rc/rc_plugin.cpp#L89

Actually, the above is what prevents more withdrawal than requested in 14 week.