### PR TITLE
Closes #3258 Fix update_median_feed when total sbd is 0

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -3266,10 +3266,14 @@ try {
                // so the combined market cap is $900 + $100 = $1000.
 
                const auto& gpo = get_dynamic_global_properties();
-               price min_price( asset( 9 * gpo.current_sbd_supply.amount, SBD_SYMBOL ), gpo.current_supply );
 
-               if( min_price > fho.current_median_history )
-                  fho.current_median_history = min_price;
+               if( gpo.current_sbd_supply.amount > 0 )
+               {
+                  price min_price( asset( 9 * gpo.current_sbd_supply.amount, SBD_SYMBOL ), gpo.current_supply );
+
+                  if( min_price > fho.current_median_history )
+                     fho.current_median_history = min_price;
+               }
             }
          }
       });


### PR DESCRIPTION
Closes #3258.
This issue can be solved with a simple IF, since if for some reason the SBD goes to zero, then there is no debt and there is no need to calculate the haircut price.
A hardfork is not needed.