### PR TITLE
Update default configs and exchange documentation

### DIFF
--- a/contrib/config-for-docker.ini
+++ b/contrib/config-for-docker.ini
@@ -9,12 +9,17 @@ log-logger = {"name":"default","level":"info","appender":"stderr"}
 log-logger = {"name":"p2p","level":"info","appender":"stderr"}
 
 # Plugin(s) to enable, may be specified multiple times
-plugin = webserver p2p json_rpc witness
+plugin = webserver p2p json_rpc witness transaction_status
 
-plugin = database_api condenser_api rc_api
+plugin = database_api condenser_api rc_api block_api network_broadcast_api transaction_status_api
 
+# Note: If using the docker image, account_history and account_history_api plugins
+# are added automatically to track single accounts when the `TRACK_ACCOUNT` environment variable is set
+# to an account name.
+
+# If using the docker image, this is set with the environment variable `TRACK_ACCOUNT`
 # Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times
-# account-history-track-account-range =
+# account-history-track-account-range = ["accountname","accountname"]
 
 # Defines a list of operations which will be explicitly logged.
 # account-history-whitelist-ops =
@@ -25,8 +30,13 @@ plugin = database_api condenser_api rc_api
 # the location of the chain shared memory files (absolute path or relative to application data dir)
 shared-file-dir = "blockchain"
 
-# Size of the shared memory file. Default: 54G
-shared-file-size = 54G
+# Size of the shared memory file. Default: 100G
+shared-file-size = 64G
+
+# Set autoscaling of shared memory file
+# If using the docker image, this is set with a default command line arugment
+# shared-file-full-threshold = 9500
+# shared-file-scale-rate = 1000
 
 # Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.
 # checkpoint =

--- a/contrib/steemd.run
+++ b/contrib/steemd.run
@@ -31,9 +31,9 @@ fi
 
 if [[ ! -z "$TRACK_ACCOUNT" ]]; then
     if [[ ! "$USE_WAY_TOO_MUCH_RAM" ]]; then
-        ARGS+=" --plugin=account_history_rocksdb --plugin=account_history_api"
+        ARGS+=" --plugin=account_history --plugin=account_history_api"
     fi
-    ARGS+=" --account-history-rocksdb-track-account-range=[\"$TRACK_ACCOUNT\",\"$TRACK_ACCOUNT\"]"
+    ARGS+=" --account-history-track-account-range=[\"$TRACK_ACCOUNT\",\"$TRACK_ACCOUNT\"]"
 fi
 
 if [[ ! "$DISABLE_SCALE_MEM" ]]; then

--- a/doc/example_config.ini
+++ b/doc/example_config.ini
@@ -1,115 +1,90 @@
-# this will need to increase depending on which plugins/apis you use
-# 54 GB should be sufficient for a consensus node
-shared-file-size = 54G
+# Console appender definition json: {"appender", "stream"}
+log-console-appender = {"appender":"stderr","stream":"std_error"}
 
-# Endpoint for P2P node to listen on
+# File appender definition json:  {"appender", "file"}
+log-file-appender = {"appender":"p2p","file":"logs/p2p/p2p.log"}
+
+# Logger definition json: {"name", "level", "appender"}
+log-logger = {"name":"default","level":"info","appender":"stderr"}
+log-logger = {"name":"p2p","level":"info","appender":"stderr"}
+
+# Plugin(s) to enable, may be specified multiple times
+plugin = webserver p2p json_rpc witness account_history transaction_status
+
+plugin = database_api condenser_api rc_api account_history_api block_api network_broadcast_api transaction_status_api
+
+# Defines a range of accounts to track as a json pair ["from","to"] [from,to] Can be specified multiple times
+account-history-track-account-range = ["accountname","accountname"]
+
+# Defines a list of operations which will be explicitly logged.
+# account-history-whitelist-ops =
+
+# Defines a list of operations which will be explicitly ignored.
+# account-history-blacklist-ops =
+
+# the location of the chain shared memory files (absolute path or relative to application data dir)
+shared-file-dir = "blockchain"
+
+# Size of the shared memory file. Default: 100G
+shared-file-size = 64G
+
+# Set autoscaling of shared memory file
+shared-file-full-threshold = 9500
+shared-file-scale-rate = 1000
+
+# Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.
+# checkpoint =
+
+# flush shared memory changes to disk every N blocks
+flush-state-interval = 0
+
+# Database edits to apply on startup (may specify multiple times)
+# edit-script =
+
+# Set the maximum size of cached feed for an account
+follow-max-feed-size = 500
+
+# Block time (in epoch seconds) when to start calculating feeds
+# follow-start-feeds = 0
+
+# Track market history by grouping orders into buckets of equal size measured in seconds specified as a JSON array of numbers
+market-history-bucket-size = [15,60,300,3600,86400]
+
+# How far back in time to track history for each bucket size, measured in the number of buckets (default: 5760)
+market-history-buckets-per-size = 5760
+
+# The local IP address and port to listen for incoming connections.
 # p2p-endpoint =
 
 # Maxmimum number of incoming connections on P2P endpoint
 # p2p-max-connections =
 
-# P2P nodes to connect to on startup (may specify multiple times)
+# The IP address and port of a remote peer to sync with. Deprecated in favor of p2p-seed-node.
 # seed-node =
 
-# Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.
-# checkpoint =
+# The IP address and port of a remote peer to sync with.
+# p2p-seed-node =
 
-# Endpoint for websocket RPC to listen on
-# rpc-endpoint =
+# User agent to advertise to peers
+p2p-user-agent = Graphene Reference Implementation
 
-# Endpoint for TLS websocket RPC to listen on
-# rpc-tls-endpoint =
+# The local IP and port to listen for incoming http connections.
+# webserver-http-endpoint =
 
-# The TLS certificate file for this server
-# server-pem =
+# The local IP and port to listen for incoming websocket connections.
+# webserver-ws-endpoint =
 
-# Password for this certificate
-# server-pem-password =
-
-# Block signing key to use for init witnesses, overrides genesis file
-# dbg-init-key =
-
-# API user specification, may be specified multiple times
-# api-user =
-
-# Set an API to be publicly available, may be specified multiple times
-public-api = database_api login_api
-
-# Plugin(s) to enable, may be specified multiple times
-enable-plugin = account_history
-
-# JSON list of [nblocks,nseconds] pairs, see doc/bcd-trigger.md
-bcd-trigger = [[0,10],[85,300]]
-
-# Defines a range of accounts to track as a json pair ["from","to"] [from,to]
-track-account-range = ["exchange_account", "exchange_account"]
-
-# Ignore posting operations, only track transfers and account updates
-# filter-posting-ops =
-
-# Database edits to apply on startup (may specify multiple times)
-# edit-script =
-
-# RPC endpoint of a trusted validating node (required)
-# trusted-node =
-
-# Set the maximum size of cached feed for an account
-# follow-max-feed-size = 500
-
-# Track market history by grouping orders into buckets of equal size measured in seconds specified as a JSON array of numbers
-# bucket-size = [15,60,300,3600,86400]
-
-# How far back in time to track history for each bucket size, measured in the number of buckets (default: 5760)
-# history-per-size = 5760
-
-# Defines a range of accounts to private messages to/from as a json pair ["from","to"] [from,to)
-# pm-account-range =
+# Number of threads used to handle queries. Default: 32.
+webserver-thread-pool-size = 256
 
 # Enable block production, even if the chain is stale.
-# enable-stale-production = false
+enable-stale-production = false
 
 # Percent of witnesses (0-99) that must be participating in order to produce blocks
-# required-participation = false
+# required-participation =
 
 # name of witness controlled by this node (e.g. initwitness )
 # witness =
 
-# name of miner and its private key (e.g. ["account","WIF PRIVATE KEY"] )
-# miner =
-
-# Number of threads to use for proof of work mining
-# mining-threads =
-
 # WIF PRIVATE KEY to be used by one or more witnesses or miners
 # private-key =
-
-# Account creation fee to be voted on upon successful POW - Minimum fee is 100.000 STEEM (written as 100000)
-# miner-account-creation-fee =
-
-# Maximum block size (in bytes) to be voted on upon successful POW - Max block size must be between 128 KB and 750 MB
-# miner-maximum-block-size =
-
-# SBD interest rate to be vote on upon successful POW - Default interest rate is 10% (written as 1000)
-# miner-sbd-interest-rate =
-
-# declare an appender named "stderr" that writes messages to the console
-[log.console_appender.stderr]
-stream=std_error
-
-# declare an appender named "p2p" that writes messages to p2p.log
-[log.file_appender.p2p]
-filename=logs/p2p/p2p.log
-# filename can be absolute or relative to this config file
-
-# route any messages logged to the default logger to the "stderr" logger we
-# declared above, if they are info level are higher
-[logger.default]
-level=info
-appenders=stderr
-
-# route messages sent to the "p2p" logger to stderr too
-[logger.p2p]
-level=info
-appenders=stderr
-
-


### PR DESCRIPTION
This updates the default example config file as well as the default docker config file. Exchange documentation has been brought up-to-date including new instructions for config files and new instructions for upgrading.

There are a few minor differences between the two config files. The non-docker example config has `account_history` and `account_history_api` listed along with `account-history-track-account-range`, and it also includes `shared-file-full-threshold` and `shared-file-scale-rate`. These are all things that are set by the docker image when using the docker config file.