### PR TITLE
fix assert message in claim_account_evaluator

### DIFF
--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -2649,7 +2649,7 @@ void claim_account_evaluator::do_apply( const claim_account_operation& o )
    else
    {
       FC_ASSERT( o.fee == wso.median_props.account_creation_fee,
-         "Cannot pay more than account creation fee. paid: ${p} fee: ${f}",
+         "Must pay the exact account creation fee. paid: ${p} fee: ${f}",
          ("p", o.fee.amount.value)
          ("f", wso.median_props.account_creation_fee) );
    }


### PR DESCRIPTION
Correction of the assert message in claim_account. The expression "more than" implies that the fee is greater than the account_creation_fee, which is not the statement in the assert.

Now using the same expression as in `account_create_operation`.