### PR TITLE
Fix automated action mira iterator logic

### DIFF
--- a/libraries/mira/include/mira/detail/rocksdb_iterator.hpp
+++ b/libraries/mira/include/mira/detail/rocksdb_iterator.hpp
@@ -407,26 +407,6 @@ public:
       return *this;
    }
 
-   rocksdb_iterator& operator=( rocksdb_iterator& other )
-   {
-      _handles = other._handles;
-      _index = other._index;
-      _snapshot = other._snapshot;
-      _db = other._db;
-      _cache = other._cache;
-      _cache_value = other._cache_value;
-
-      if ( other._iter )
-      {
-         _iter.reset( _db->NewIterator( _opts, &*(*_handles)[ _index ] ) );
-
-         if( other._iter->Valid() )
-            _iter->Seek( other._iter->key() );
-      }
-
-      return *this;
-   }
-
    rocksdb_iterator& operator=( rocksdb_iterator&& other )
    {
       _handles = other._handles;

--- a/libraries/plugins/witness/block_producer.cpp
+++ b/libraries/plugins/witness/block_producer.cpp
@@ -198,7 +198,17 @@ void block_producer::apply_pending_transactions(
          temp_session.squash();
          total_block_size = new_total_size;
          required_actions.push_back( pending_required_itr->action );
+
+#ifdef ENABLE_MIRA
+         auto old = pending_required_itr++;
+         if( !( pending_required_itr != pending_required_action_idx.end() && pending_required_itr->execution_time <= when ) )
+         {
+            pending_required_itr = pending_required_action_idx.iterator_to( *old );
+            ++pending_required_itr;
+         }
+#else
          ++pending_required_itr;
+#endif
       }
       catch( fc::exception& e )
       {


### PR DESCRIPTION
Some SMT ICO MIRA tests were failing.

This PR fixes those tests and removes a redundant `rocksdb_iterator` copy operator.