### PR TITLE
Special Destination Account

### DIFF
--- a/libraries/protocol/include/steem/protocol/smt_util.hpp
+++ b/libraries/protocol/include/steem/protocol/smt_util.hpp
@@ -3,6 +3,7 @@
 #include <steem/protocol/types.hpp>
 
 #define SMT_DESTINATION_PREFIX         "$"
+#define SMT_DESTINATION_ACCOUNT_PREFIX SMT_DESTINATION_PREFIX "!"
 #define SMT_DESTINATION_VESTING_SUFFIX ".vesting"
 #define SMT_DESTINATION_FROM           unit_target_type( SMT_DESTINATION_PREFIX "from" )
 #define SMT_DESTINATION_FROM_VESTING   unit_target_type( SMT_DESTINATION_PREFIX "from" SMT_DESTINATION_VESTING_SUFFIX )

--- a/libraries/protocol/smt_util.cpp
+++ b/libraries/protocol/smt_util.cpp
@@ -22,13 +22,10 @@ bool is_rewards( const unit_target_type& unit_target )
 
 bool is_founder_vesting( const unit_target_type& unit_target )
 {
-   if ( unit_target == SMT_DESTINATION_FROM_VESTING )
-      return false;
-
    std::string unit_target_str = unit_target;
-   if ( unit_target_str.size() > std::strlen( SMT_DESTINATION_PREFIX ) + std::strlen( SMT_DESTINATION_VESTING_SUFFIX ) )
+   if ( unit_target_str.size() > std::strlen( SMT_DESTINATION_ACCOUNT_PREFIX ) + std::strlen( SMT_DESTINATION_VESTING_SUFFIX ) )
    {
-      auto pos = unit_target_str.find( SMT_DESTINATION_PREFIX );
+      auto pos = unit_target_str.find( SMT_DESTINATION_ACCOUNT_PREFIX );
       if ( pos != std::string::npos && pos == 0 )
       {
          std::size_t suffix_len = std::strlen( SMT_DESTINATION_VESTING_SUFFIX );
@@ -82,20 +79,21 @@ account_name_type get_unit_target_account( const unit_target_type& unit_target )
       return account_name_type( unit_target );
 
    // This is a special unit target destination in the form of $alice.vesting
-   FC_ASSERT( unit_target.size() > std::strlen( SMT_DESTINATION_PREFIX ) + std::strlen( SMT_DESTINATION_VESTING_SUFFIX ),
+   FC_ASSERT( unit_target.size() > std::strlen( SMT_DESTINATION_ACCOUNT_PREFIX ) + std::strlen( SMT_DESTINATION_VESTING_SUFFIX ),
       "Unit target '${target}' is malformed", ("target", unit_target) );
 
    std::string str_name = unit_target;
-   auto pos = str_name.find( SMT_DESTINATION_PREFIX );
-   FC_ASSERT( pos != std::string::npos && pos == 0, "Expected SMT destination prefix '${prefix}' for unit target '${target}'.",
-      ("prefix", SMT_DESTINATION_PREFIX)("target", unit_target) );
+   auto pos = str_name.find( SMT_DESTINATION_ACCOUNT_PREFIX );
+   FC_ASSERT( pos != std::string::npos && pos == 0, "Expected SMT destination account prefix '${prefix}' for unit target '${target}'.",
+      ("prefix", SMT_DESTINATION_ACCOUNT_PREFIX)("target", unit_target) );
 
    std::size_t suffix_len = std::strlen( SMT_DESTINATION_VESTING_SUFFIX );
    FC_ASSERT( !str_name.compare( str_name.size() - suffix_len, suffix_len, SMT_DESTINATION_VESTING_SUFFIX ),
       "Expected SMT destination vesting suffix '${suffix}' for unit target '${target}'.",
          ("suffix", SMT_DESTINATION_VESTING_SUFFIX)("target", unit_target) );
 
-   account_name_type unit_target_account = str_name.substr( 1, str_name.size() - suffix_len - 1 );
+   std::size_t prefix_len = std::strlen( SMT_DESTINATION_ACCOUNT_PREFIX );
+   account_name_type unit_target_account = str_name.substr( prefix_len, str_name.size() - suffix_len - prefix_len );
    FC_ASSERT( is_valid_account_name( unit_target_account ), "The derived unit target account name '${name}' is invalid.",
       ("name", unit_target_account) );
 

--- a/tests/tests/smt_operation_tests.cpp
+++ b/tests/tests/smt_operation_tests.cpp
@@ -3297,12 +3297,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    valid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3312,12 +3312,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    valid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3377,13 +3377,13 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 1 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3393,7 +3393,7 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 }
       },
@@ -3417,13 +3417,13 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_FROM, 1 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3433,13 +3433,13 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_FROM, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3455,13 +3455,13 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_FROM_VESTING, 1 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3471,13 +3471,13 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_FROM_VESTING, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3493,13 +3493,13 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_VESTING, 1 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3509,13 +3509,13 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_VESTING, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3531,12 +3531,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3547,12 +3547,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3574,7 +3574,7 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3584,12 +3584,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3605,12 +3605,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { "$market_malformed", 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3620,12 +3620,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3641,12 +3641,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3656,12 +3656,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { "$market_maker1", 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3677,12 +3677,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3692,12 +3692,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { "$rewardsx", 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3714,12 +3714,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    valid_generation_policy2.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3729,7 +3729,7 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    valid_generation_policy2.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {}
@@ -3745,12 +3745,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3764,7 +3764,7 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3781,7 +3781,7 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
@@ -3791,12 +3791,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3816,7 +3816,7 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3827,12 +3827,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_validate )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3898,12 +3898,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "elaine", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3913,12 +3913,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3940,12 +3940,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "elaine", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3955,12 +3955,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -3982,12 +3982,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -3997,12 +3997,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "elaine", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -4024,12 +4024,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "elaine", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -4039,12 +4039,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "elaine", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -4066,12 +4066,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$elaine.vesting", 2 },
+         { "$!elaine.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -4081,12 +4081,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -4108,12 +4108,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$elaine.vesting", 2 },
+         { "$!elaine.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -4123,12 +4123,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -4150,12 +4150,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -4165,12 +4165,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$elaine.vesting", 1 },
+         { "$!elaine.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -4192,12 +4192,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -4207,12 +4207,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    invalid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$elaine.vesting", 1 },
+         { "$!elaine.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },
@@ -4235,12 +4235,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    valid_generation_policy.pre_soft_cap_unit = {
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 }
       },
       {
          { "alice", 2 },
-         { "$alice.vesting", 2 },
+         { "$!alice.vesting", 2 },
          { SMT_DESTINATION_MARKET_MAKER, 2 },
          { SMT_DESTINATION_REWARDS, 2 },
          { SMT_DESTINATION_FROM, 2 },
@@ -4250,12 +4250,12 @@ BOOST_AUTO_TEST_CASE( smt_setup_apply )
    valid_generation_policy.post_soft_cap_unit = {
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 }
       },
       {
          { "alice", 1 },
-         { "$alice.vesting", 1 },
+         { "$!alice.vesting", 1 },
          { SMT_DESTINATION_MARKET_MAKER, 1 },
          { SMT_DESTINATION_REWARDS, 1 },
          { SMT_DESTINATION_FROM, 1 },

--- a/tests/tests/smt_operation_time_tests.cpp
+++ b/tests/tests/smt_operation_time_tests.cpp
@@ -409,13 +409,13 @@ BOOST_AUTO_TEST_CASE( smt_ico_payouts_special_destinations )
          get_generation_unit(
          {
             { SMT_DESTINATION_MARKET_MAKER, 3 },
-            { "$george.vesting", 2 }
+            { "$!george.vesting", 2 }
          },
          {
             { SMT_DESTINATION_FROM, 5 },
             { SMT_DESTINATION_MARKET_MAKER, 1 },
             { SMT_DESTINATION_REWARDS, 2 },
-            { "$george.vesting", 2 }
+            { "$!george.vesting", 2 }
          } ), /* post_soft_cap_unit */
          50,                                                            /* min_unit_ratio */
          100                                                            /* max_unit_ratio */

--- a/tests/tests/smt_tests.cpp
+++ b/tests/tests/smt_tests.cpp
@@ -155,19 +155,19 @@ BOOST_AUTO_TEST_CASE( smt_founder_vesting )
    BOOST_TEST_MESSAGE( "Testing: is_founder_vesting and get_unit_target_account" );
 
    BOOST_TEST_MESSAGE( " -- Valid founder vesting" );
-   BOOST_REQUIRE( smt::unit_target::is_founder_vesting( "$alice.vesting" ) );
+   BOOST_REQUIRE( smt::unit_target::is_founder_vesting( "$!alice.vesting" ) );
 
    BOOST_TEST_MESSAGE( " -- Account name parsing" );
-   BOOST_REQUIRE( smt::unit_target::get_unit_target_account( "$alice.vesting" ) == account_name_type( "alice" ) );
+   BOOST_REQUIRE( smt::unit_target::get_unit_target_account( "$!alice.vesting" ) == account_name_type( "alice" ) );
 
    BOOST_TEST_MESSAGE( " -- No possible room for an account name" );
-   BOOST_REQUIRE( smt::unit_target::is_founder_vesting( "$.vesting" ) == false );
+   BOOST_REQUIRE( smt::unit_target::is_founder_vesting( "$!.vesting" ) == false );
 
    BOOST_TEST_MESSAGE( " -- Meant to be founder vesting" );
-   BOOST_REQUIRE( smt::unit_target::is_founder_vesting( "$@.vesting" ) );
+   BOOST_REQUIRE( smt::unit_target::is_founder_vesting( "$!@.vesting" ) );
 
    BOOST_TEST_MESSAGE( " -- Invalid account name upon retrieval" );
-   BOOST_REQUIRE_THROW( smt::unit_target::get_unit_target_account( "$@.vesting" ), fc::assert_exception );
+   BOOST_REQUIRE_THROW( smt::unit_target::get_unit_target_account( "$!@.vesting" ), fc::assert_exception );
 
    BOOST_TEST_MESSAGE( " -- SMT special destinations" );
    BOOST_REQUIRE( smt::unit_target::is_founder_vesting( SMT_DESTINATION_FROM_VESTING ) == false );
@@ -178,8 +178,8 @@ BOOST_AUTO_TEST_CASE( smt_founder_vesting )
    BOOST_REQUIRE( smt::unit_target::is_founder_vesting( SMT_DESTINATION_VESTING ) == false );
 
    BOOST_TEST_MESSAGE( " -- Partial founder vesting special name" );
-   BOOST_REQUIRE( smt::unit_target::is_founder_vesting( "$bob" ) == false );
-   BOOST_REQUIRE_THROW( smt::unit_target::get_unit_target_account( "$bob" ), fc::assert_exception );
+   BOOST_REQUIRE( smt::unit_target::is_founder_vesting( "$!bob" ) == false );
+   BOOST_REQUIRE_THROW( smt::unit_target::get_unit_target_account( "$!bob" ), fc::assert_exception );
 
    BOOST_REQUIRE( smt::unit_target::is_founder_vesting( "bob.vesting" ) == false );
 


### PR DESCRIPTION
We should change special destination account prefix from `$` to `$!`, this allows for all valid account names to be properly specified.