### PR TITLE
added missing precision reflect in header

### DIFF
--- a/libraries/protocol/include/steem/protocol/smt_operations.hpp
+++ b/libraries/protocol/include/steem/protocol/smt_operations.hpp
@@ -215,6 +215,7 @@ FC_REFLECT(
    (control_account)
    (symbol)
    (smt_creation_fee)
+   (precision)
    (extensions)
 )
 


### PR DESCRIPTION
On testnet, when trying to broadcast `smt_create`, no matter what I set for precision, I was seeing this error:

```json
{"error":"network_broadcast_api.broadcast_transaction: Assert Exception:symbol.decimals() == precision: Mismatch between redundantly provided precision 3 vs 0"}
```

Looks like `precision` was missing here:

https://github.com/steemit/steem/blob/e134c404b67fae7dba439162344332e369a4c269/libraries/protocol/include/steem/protocol/smt_operations.hpp#L213-L219

Original error case:

```yaml
- request:
    method: post
    uri: https://testnet.steemitdev.com/
    body:
      encoding: UTF-8
      string: '{"jsonrpc":"2.0","id":9,"method":"network_broadcast_api.broadcast_transaction","params":{"trx":{"id":"d4933f938f20a9d7bf6f29d392f3b832be5d395b","ref_block_num":38606,"ref_block_prefix":1464797738,"expiration":"2019-10-17T05:53:00","operations":[{"type":"smt_create_operation","value":{"control_account":"inertia","symbol":{"nai":"@@422838704","decimals":3},"smt_creation_fee":{"amount":"1000","precision":3,"nai":"@@000000013"},"precision":3,"extensions":[]}}],"extensions":[],"signatures":["1b4da49ee4355fecd221f769d827c6dce1733c3dd39b4468fa8ad2f72c444cbc206609abbe5a6b27e4c9706fbf4fa703c06b4f4da6c9ff92a10122f742719a25c9"]}}}'
    headers:
      Content-Type:
      - application/json; charset=utf-8
      User-Agent:
      - steem-ruby/0.9.4
      Accept-Encoding:
      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
      Accept:
      - "*/*"
      Host:
      - testnet.steemitdev.com
      Content-Length:
      - '123'
  response:
    status:
      code: 200
      message: OK
    headers:
      Access-Control-Allow-Headers:
      - DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range
      Access-Control-Allow-Methods:
      - GET, POST, OPTIONS
      Access-Control-Allow-Origin:
      - "*"
      Content-Type:
      - application/json
      Date:
      - Thu, 17 Oct 2019 05:43:03 GMT
      Server:
      - nginx
      Strict-Transport-Security:
      - max-age=31557600; includeSubDomains; preload
      Content-Length:
      - '1796'
      Connection:
      - keep-alive
    body:
      encoding: UTF-8
      string: '{"jsonrpc":"2.0","error":{"code":-32000,"message":"Assert Exception:symbol.decimals()
        == precision: Mismatch between redundantly provided precision 3 vs 0","data":{"code":10,"name":"assert_exception","message":"Assert
        Exception","stack":[{"context":{"level":"error","file":"smt_operations.cpp","line":22,"method":"validate","hostname":"","timestamp":"2019-10-17T05:43:03"},"format":"symbol.decimals()
        == precision: Mismatch between redundantly provided precision ${prec1} vs
        ${prec2}","data":{"prec1":3,"prec2":0}},{"context":{"level":"warn","file":"database.cpp","line":3449,"method":"_apply_transaction","hostname":"","timestamp":"2019-10-17T05:43:03"},"format":"","data":{"trx":{"ref_block_num":38606,"ref_block_prefix":1464797738,"expiration":"2019-10-17T05:53:00","operations":[{"type":"smt_create_operation","value":{"control_account":"inertia","symbol":{"nai":"@@422838704","decimals":3},"smt_creation_fee":{"amount":"1000","precision":3,"nai":"@@000000013"},"extensions":[]}}],"extensions":[],"signatures":["1b4da49ee4355fecd221f769d827c6dce1733c3dd39b4468fa8ad2f72c444cbc206609abbe5a6b27e4c9706fbf4fa703c06b4f4da6c9ff92a10122f742719a25c9"]}}},{"context":{"level":"warn","file":"database.cpp","line":907,"method":"push_transaction","hostname":"","timestamp":"2019-10-17T05:43:03"},"format":"","data":{"trx":{"ref_block_num":38606,"ref_block_prefix":1464797738,"expiration":"2019-10-17T05:53:00","operations":[{"type":"smt_create_operation","value":{"control_account":"inertia","symbol":{"nai":"@@422838704","decimals":3},"smt_creation_fee":{"amount":"1000","precision":3,"nai":"@@000000013"},"extensions":[]}}],"extensions":[],"signatures":["1b4da49ee4355fecd221f769d827c6dce1733c3dd39b4468fa8ad2f72c444cbc206609abbe5a6b27e4c9706fbf4fa703c06b4f4da6c9ff92a10122f742719a25c9"]}}}]}},"id":9}'
    http_version:
  recorded_at: Thu, 17 Oct 2019 05:43:03 GMT
recorded_with: VCR 4.0.0
```