### PR TITLE
Update available reward curves and initial reward balance

### DIFF
--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -5082,7 +5082,7 @@ void database::apply_hardfork( uint32_t hardfork )
                rfo.recent_claims = STEEM_HF_17_RECENT_CLAIMS;
 #endif
                rfo.author_reward_curve = curve_id::quadratic;
-               rfo.curation_reward_curve = curve_id::bounded_curation;
+               rfo.curation_reward_curve = curve_id::bounded;
             });
 
             // As a shortcut in payout processing, we use the id as an array index.

--- a/libraries/chain/smt_evaluator.cpp
+++ b/libraries/chain/smt_evaluator.cpp
@@ -110,6 +110,7 @@ void smt_create_evaluator::do_apply( const smt_create_operation& o )
       token.liquid_symbol = o.symbol;
       token.control_account = o.control_account;
       token.market_maker.token_balance = asset( 0, token.liquid_symbol );
+      token.reward_balance = asset( 0, token.liquid_symbol );
    });
 
    remove_from_nai_pool( _db, o.symbol );

--- a/libraries/chain/util/reward.cpp
+++ b/libraries/chain/util/reward.cpp
@@ -71,7 +71,7 @@ uint128_t evaluate_reward_curve( const uint128_t& rshares, const protocol::curve
             result = rshares_plus_s * rshares_plus_s - content_constant * content_constant;
          }
          break;
-      case protocol::bounded_curation:
+      case protocol::bounded:
          {
             const uint128_t& content_constant = var1;
             uint128_t two_alpha = content_constant * 2;

--- a/libraries/protocol/include/steem/protocol/misc_utilities.hpp
+++ b/libraries/protocol/include/steem/protocol/misc_utilities.hpp
@@ -5,7 +5,7 @@ namespace steem { namespace protocol {
 enum curve_id
 {
    quadratic,
-   bounded_curation,
+   bounded,
    linear,
    square_root,
    convergent_linear,
@@ -18,7 +18,7 @@ enum curve_id
 FC_REFLECT_ENUM(
    steem::protocol::curve_id,
    (quadratic)
-   (bounded_curation)
+   (bounded)
    (linear)
    (square_root)
    (convergent_linear)

--- a/libraries/protocol/smt_operations.cpp
+++ b/libraries/protocol/smt_operations.cpp
@@ -274,21 +274,27 @@ struct smt_set_runtime_parameters_operation_visitor
 
       switch( param_rewards.author_reward_curve )
       {
-         case linear:
          case quadratic:
+         case linear:
+         case square_root:
+         case convergent_linear:
+         case convergent_square_root:
             break;
          default:
-            FC_ASSERT( false, "Author Reward Curve must be linear or quadratic" );
+            FC_ASSERT( false, "Author Reward Curve must be quadratic, linear, square_root, convergent_linear, or convergent_square_root." );
       }
 
       switch( param_rewards.curation_reward_curve )
       {
+         case quadratic:
          case linear:
          case square_root:
+         case convergent_linear:
+         case convergent_square_root:
          case bounded_curation:
             break;
          default:
-            FC_ASSERT( false, "Curation Reward Curve must be linear, square_root, or bounded_curation." );
+            FC_ASSERT( false, "Curation Reward Curve must be quadratic, linear, square_root, convergent_linear, convergent_square_root or bounded_curation." );
       }
    }
 

--- a/libraries/protocol/smt_operations.cpp
+++ b/libraries/protocol/smt_operations.cpp
@@ -279,9 +279,10 @@ struct smt_set_runtime_parameters_operation_visitor
          case square_root:
          case convergent_linear:
          case convergent_square_root:
+         case bounded:
             break;
          default:
-            FC_ASSERT( false, "Author Reward Curve must be quadratic, linear, square_root, convergent_linear, or convergent_square_root." );
+            FC_ASSERT( false, "Author Reward Curve must be quadratic, linear, square_root, convergent_linear, convergent_square_root or bounded." );
       }
 
       switch( param_rewards.curation_reward_curve )
@@ -291,10 +292,10 @@ struct smt_set_runtime_parameters_operation_visitor
          case square_root:
          case convergent_linear:
          case convergent_square_root:
-         case bounded_curation:
+         case bounded:
             break;
          default:
-            FC_ASSERT( false, "Curation Reward Curve must be quadratic, linear, square_root, convergent_linear, convergent_square_root or bounded_curation." );
+            FC_ASSERT( false, "Curation Reward Curve must be quadratic, linear, square_root, convergent_linear, convergent_square_root or bounded." );
       }
    }
 

--- a/tests/tests/smt_operation_tests.cpp
+++ b/tests/tests/smt_operation_tests.cpp
@@ -2668,17 +2668,6 @@ BOOST_AUTO_TEST_CASE( smt_set_runtime_parameters_validate )
       op.runtime_parameters.insert( vote_regen );
       op.validate();
 
-      /*
-       * Conditions to test:
-       *
-       * percent_curation_rewards <= 10000
-       *
-       * percent_content_rewards + percent_curation_rewards == 10000
-       *
-       * author_reward_curve must be quadratic or linear
-       *
-       * curation_reward_curve must be bounded_curation, linear, or square_root
-       */
       BOOST_TEST_MESSAGE( "--- Failure when percent_curation_rewards greater than 10000" );
       smt_param_rewards_v1 rewards;
       rewards.content_constant = STEEM_CONTENT_CONSTANT_HF0;
@@ -2695,42 +2684,56 @@ BOOST_AUTO_TEST_CASE( smt_set_runtime_parameters_validate )
       op.runtime_parameters.insert( rewards );
       op.validate();
 
-      BOOST_TEST_MESSAGE( "--- Success when author curve is quadratic" );
-      rewards.author_reward_curve = curve_id::quadratic;
-      op.runtime_parameters.clear();
-      op.runtime_parameters.insert( rewards );
-      op.validate();
+      auto invalid_author_reward_curves = {
+         curve_id::bounded_curation
+      };
 
-      BOOST_TEST_MESSAGE( "--- Failure when author curve is bounded_curation" );
-      rewards.author_reward_curve = curve_id::bounded_curation;
-      op.runtime_parameters.clear();
-      op.runtime_parameters.insert( rewards );
-      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      rewards = {};
+      for ( auto& curve : invalid_author_reward_curves )
+      {
+         BOOST_TEST_MESSAGE( std::string( "--- Failure when author curve is " ) + fc::reflector< steem::protocol::curve_id >::to_string( curve ) );
+         rewards.author_reward_curve = curve;
+         op.runtime_parameters.clear();
+         op.runtime_parameters.insert( rewards );
+         BOOST_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      }
 
-      BOOST_TEST_MESSAGE( "--- Failure when author curve is square_root" );
-      rewards.author_reward_curve = curve_id::square_root;
-      op.runtime_parameters.clear();
-      op.runtime_parameters.insert( rewards );
-      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      auto valid_author_reward_curves = {
+         curve_id::quadratic,
+         curve_id::linear,
+         curve_id::square_root,
+         curve_id::convergent_linear,
+         curve_id::convergent_square_root
+      };
 
-      BOOST_TEST_MESSAGE( "--- Success when curation curve is bounded_curation" );
-      rewards.author_reward_curve = curve_id::linear;
-      rewards.curation_reward_curve = curve_id::bounded_curation;
-      op.runtime_parameters.clear();
-      op.runtime_parameters.insert( rewards );
-      op.validate();
+      rewards = {};
+      for ( auto& curve : valid_author_reward_curves )
+      {
+         BOOST_TEST_MESSAGE( std::string( "--- Success when author curve is " ) + fc::reflector< steem::protocol::curve_id >::to_string( curve ) );
+         rewards.author_reward_curve = curve;
+         op.runtime_parameters.clear();
+         op.runtime_parameters.insert( rewards );
+         op.validate();
+      }
 
-      BOOST_TEST_MESSAGE( "--- Success when curation curve is linear" );
-      rewards.curation_reward_curve = curve_id::linear;
-      op.runtime_parameters.clear();
-      op.runtime_parameters.insert( rewards );
-      op.validate();
+      auto valid_curation_reward_curves = {
+         curve_id::quadratic,
+         curve_id::linear,
+         curve_id::square_root,
+         curve_id::convergent_linear,
+         curve_id::convergent_square_root,
+         curve_id::bounded_curation
+      };
 
-      BOOST_TEST_MESSAGE( "--- Failure when curation curve is quadratic" );
-      rewards.curation_reward_curve = curve_id::quadratic;
-      op.runtime_parameters.clear();
-      op.runtime_parameters.insert( rewards );
-      STEEM_REQUIRE_THROW( op.validate(), fc::assert_exception );
+      rewards = {};
+      for ( auto& curve : valid_curation_reward_curves )
+      {
+         BOOST_TEST_MESSAGE( std::string( "--- Success when curation curve is " ) + fc::reflector< steem::protocol::curve_id >::to_string( curve ) );
+         rewards.curation_reward_curve = curve;
+         op.runtime_parameters.clear();
+         op.runtime_parameters.insert( rewards );
+         op.validate();
+      }
 
       // Literally nothing to test for smt_param_allow_downvotes because it can only be true or false.
       // Inclusion success was tested in initial positive validation at the beginning of the test.

--- a/tests/tests/smt_operation_tests.cpp
+++ b/tests/tests/smt_operation_tests.cpp
@@ -2684,30 +2684,17 @@ BOOST_AUTO_TEST_CASE( smt_set_runtime_parameters_validate )
       op.runtime_parameters.insert( rewards );
       op.validate();
 
-      auto invalid_author_reward_curves = {
-         curve_id::bounded_curation
-      };
-
-      rewards = {};
-      for ( auto& curve : invalid_author_reward_curves )
-      {
-         BOOST_TEST_MESSAGE( std::string( "--- Failure when author curve is " ) + fc::reflector< steem::protocol::curve_id >::to_string( curve ) );
-         rewards.author_reward_curve = curve;
-         op.runtime_parameters.clear();
-         op.runtime_parameters.insert( rewards );
-         BOOST_REQUIRE_THROW( op.validate(), fc::assert_exception );
-      }
-
-      auto valid_author_reward_curves = {
+      auto valid_curves = {
          curve_id::quadratic,
          curve_id::linear,
          curve_id::square_root,
          curve_id::convergent_linear,
-         curve_id::convergent_square_root
+         curve_id::convergent_square_root,
+         curve_id::bounded
       };
 
       rewards = {};
-      for ( auto& curve : valid_author_reward_curves )
+      for ( auto& curve : valid_curves )
       {
          BOOST_TEST_MESSAGE( std::string( "--- Success when author curve is " ) + fc::reflector< steem::protocol::curve_id >::to_string( curve ) );
          rewards.author_reward_curve = curve;
@@ -2716,17 +2703,8 @@ BOOST_AUTO_TEST_CASE( smt_set_runtime_parameters_validate )
          op.validate();
       }
 
-      auto valid_curation_reward_curves = {
-         curve_id::quadratic,
-         curve_id::linear,
-         curve_id::square_root,
-         curve_id::convergent_linear,
-         curve_id::convergent_square_root,
-         curve_id::bounded_curation
-      };
-
       rewards = {};
-      for ( auto& curve : valid_curation_reward_curves )
+      for ( auto& curve : valid_curves )
       {
          BOOST_TEST_MESSAGE( std::string( "--- Success when curation curve is " ) + fc::reflector< steem::protocol::curve_id >::to_string( curve ) );
          rewards.curation_reward_curve = curve;


### PR DESCRIPTION
Resolves #3547.
Resolves #3540.

~~This PR makes all curves available for curation and rewards on SMTs with the exception of `bounded_curation` which is only available as a curation curve.~~

This PR renames `bounded_curation` to `bounded` and makes all possible curves available for author and curation rewards on SMTs.