### PR TITLE
Prevent emission to account that does not exists

### DIFF
--- a/libraries/chain/smt_evaluator.cpp
+++ b/libraries/chain/smt_evaluator.cpp
@@ -279,15 +279,16 @@ void smt_setup_emissions_evaluator::do_apply( const smt_setup_emissions_operatio
             ("s", SMT_EMISSION_MIN_INTERVAL_SECONDS)("end", *end_time) );
       }
       
-      for ( const auto& e : o.emissions_unit.token_unit )
-      {
-          if (smt::unit_target::is_founder_vesting( e.first ))
-          {
+     for ( const auto& e : o.emissions_unit.token_unit )
+     {
+        if (smt::unit_target::is_account_name_type( e.first ))
+           {
               std::string name = e.first;
+              ilog(name);
               auto acc = _db.find<account_object, by_name>(name);
-              FC_ASSERT(acc != nullptr, "Invalid emission destiname, account ${a} must exist", ("a", name));
-          }
-      }
+              FC_ASSERT(acc != nullptr, "Invalid emission destination, account ${a} must exist", ("a", name));
+           }
+     }
 
       _db.create< smt_token_emissions_object >( [&]( smt_token_emissions_object& eo )
       {

--- a/libraries/chain/smt_evaluator.cpp
+++ b/libraries/chain/smt_evaluator.cpp
@@ -281,12 +281,11 @@ void smt_setup_emissions_evaluator::do_apply( const smt_setup_emissions_operatio
       
      for ( const auto& e : o.emissions_unit.token_unit )
      {
-        if (smt::unit_target::is_account_name_type( e.first ))
+        if ( smt::unit_target::is_account_name_type( e.first ) )
            {
-              std::string name = e.first;
-              ilog(name);
-              auto acc = _db.find<account_object, by_name>(name);
-              FC_ASSERT(acc != nullptr, "Invalid emission destination, account ${a} must exist", ("a", name));
+              std::string name = smt::unit_target::get_unit_target_account( e.first );
+              auto acc = _db.find<account_object, by_name>( name );
+              FC_ASSERT( acc != nullptr, "Invalid emission destination, account ${a} must exist", ("a", name) );
            }
      }
 

--- a/libraries/chain/smt_evaluator.cpp
+++ b/libraries/chain/smt_evaluator.cpp
@@ -278,6 +278,16 @@ void smt_setup_emissions_evaluator::do_apply( const smt_setup_emissions_operatio
             "New token emissions must begin no earlier than ${s} seconds after the last emission. Last emission time: ${end}",
             ("s", SMT_EMISSION_MIN_INTERVAL_SECONDS)("end", *end_time) );
       }
+      
+      for ( const auto& e : o.emissions_unit.token_unit )
+      {
+          if (smt::unit_target::is_founder_vesting( e.first ))
+          {
+              std::string name = e.first;
+              auto acc = _db.find<account_object, by_name>(name);
+              FC_ASSERT(acc != nullptr, "Invalid emission destiname, account ${a} must exist", ("a", name));
+          }
+      }
 
       _db.create< smt_token_emissions_object >( [&]( smt_token_emissions_object& eo )
       {


### PR DESCRIPTION
Add check on smt_setup_emissions_evaluator to prevent users from submitting emissions to non-existent accounts.