### PR TITLE
Proposal hf23 special power down steemit accounts

### DIFF
--- a/libraries/chain/sps_evaluator.cpp
+++ b/libraries/chain/sps_evaluator.cpp
@@ -74,8 +74,11 @@ void update_proposal_votes_evaluator::do_apply( const update_proposal_votes_oper
    {
       FC_ASSERT( _db.has_hardfork( STEEM_PROPOSALS_HARDFORK ), "Proposals functionality not enabled until hardfork ${hf}", ("hf", STEEM_PROPOSALS_HARDFORK) );
 
-      const auto& account = _db.get_account( o.voter );
-      FC_ASSERT( account.can_vote, "Account has declined its voting rights." );
+      if( _db.has_hardfork( STEEM_HARDFORK_0_23 ) )
+      {
+         const auto& account = _db.get_account( o.voter );
+         FC_ASSERT( account.can_vote, "Account has declined its voting rights." );
+      }
 
       const auto& pidx = _db.get_index< proposal_index >().indices().get< by_proposal_id >();
       const auto& pvidx = _db.get_index< proposal_vote_index >().indices().get< by_voter_proposal >();

--- a/libraries/chain/sps_evaluator.cpp
+++ b/libraries/chain/sps_evaluator.cpp
@@ -74,6 +74,9 @@ void update_proposal_votes_evaluator::do_apply( const update_proposal_votes_oper
    {
       FC_ASSERT( _db.has_hardfork( STEEM_PROPOSALS_HARDFORK ), "Proposals functionality not enabled until hardfork ${hf}", ("hf", STEEM_PROPOSALS_HARDFORK) );
 
+      const auto& account = _db.get_account( o.voter );
+      FC_ASSERT( account.can_vote, "Account has declined its voting rights." );
+
       const auto& pidx = _db.get_index< proposal_index >().indices().get< by_proposal_id >();
       const auto& pvidx = _db.get_index< proposal_vote_index >().indices().get< by_voter_proposal >();
 

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -1253,9 +1253,18 @@ void withdraw_vesting_evaluator::do_apply( const withdraw_vesting_operation& o )
    }
    else
    {
+      bool is_special_case_hf23 = false;
+      if ( _db.head_block_time() < STEEM_HARDFORK_0_23_TIME_NO_EFFECT )
+      {
+         if( hardfork23::get_steemit_accounts().count( o.account ) )
+            is_special_case_hf23 = true;
+      }
+
       int vesting_withdraw_intervals = STEEM_VESTING_WITHDRAW_INTERVALS_PRE_HF_16;
       if( _db.has_hardfork( STEEM_HARDFORK_0_16__551 ) )
          vesting_withdraw_intervals = STEEM_VESTING_WITHDRAW_INTERVALS; /// 13 weeks = 1 quarter of a year
+      if( is_special_case_hf23 )
+         vesting_withdraw_intervals = STEEM_VESTING_WITHDRAW_INTERVALS_SPECIAL_CASE_HF_23;
 
       _db.modify( account, [&]( account_object& a )
       {

--- a/libraries/chain/steem_evaluator.cpp
+++ b/libraries/chain/steem_evaluator.cpp
@@ -1263,7 +1263,7 @@ void withdraw_vesting_evaluator::do_apply( const withdraw_vesting_operation& o )
       int vesting_withdraw_intervals = STEEM_VESTING_WITHDRAW_INTERVALS_PRE_HF_16;
       if( _db.has_hardfork( STEEM_HARDFORK_0_16__551 ) )
          vesting_withdraw_intervals = STEEM_VESTING_WITHDRAW_INTERVALS; /// 13 weeks = 1 quarter of a year
-      if( is_special_case_hf23 )
+      if( _db.has_hardfork( STEEM_HARDFORK_0_23 ) && is_special_case_hf23 )
          vesting_withdraw_intervals = STEEM_VESTING_WITHDRAW_INTERVALS_SPECIAL_CASE_HF_23;
 
       _db.modify( account, [&]( account_object& a )

--- a/libraries/protocol/hardfork.d/0_23.hf
+++ b/libraries/protocol/hardfork.d/0_23.hf
@@ -2,8 +2,29 @@
 #define STEEM_HARDFORK_0_23 23
 #define STEEM_SMT_HARDFORK STEEM_HARDFORK_0_23
 
-#define STEEM_HARDFORK_0_23_TIME 1597970800 // Future 2020...
+#define STEEM_HARDFORK_0_23_TIME 1591876800 // Thursday, June 11, 2020 12:00:00 PM
 
 #define STEEM_HARDFORK_0_23_VERSION hardfork_version( 0, 23 )
+
+#define STEEM_HARDFORK_0_23_TIME_NO_EFFECT 1704067200 // Monday, January 1, 2024 12:00:00 AM
+
+namespace hardfork23
+{
+
+inline static const std::set< std::string >& get_steemit_accounts()
+{
+   static const std::set< std::string > steemit_accounts
+   {
+    "misterdelegation",
+    "steem",
+    "steemit",
+    "steemit2",
+    "steemitadmin"
+   };
+
+   return steemit_accounts;
+}
+
+}
 
 #endif

--- a/libraries/protocol/hardfork.d/0_24.hf
+++ b/libraries/protocol/hardfork.d/0_24.hf
@@ -1,0 +1,9 @@
+#ifndef STEEM_HARDFORK_0_24
+#define STEEM_HARDFORK_0_24 24
+#define STEEM_SMT_HARDFORK STEEM_HARDFORK_0_24
+
+#define STEEM_HARDFORK_0_24_TIME 1597970800 // Future 2020...
+
+#define STEEM_HARDFORK_0_24_VERSION hardfork_version( 0, 24 )
+
+#endif

--- a/libraries/protocol/include/steem/protocol/config.hpp
+++ b/libraries/protocol/include/steem/protocol/config.hpp
@@ -9,7 +9,7 @@
 // This is checked by get_config_check.sh called from Dockerfile
 
 #ifdef IS_TEST_NET
-#define STEEM_BLOCKCHAIN_VERSION              ( version(0, 23, 0) )
+#define STEEM_BLOCKCHAIN_VERSION              ( version(0, 24, 0) )
 
 #define STEEM_INIT_PRIVATE_KEY                (fc::ecc::private_key::regenerate(fc::sha256::hash(std::string("init_key"))))
 #define STEEM_INIT_PUBLIC_KEY_STR             (std::string( steem::protocol::public_key_type(STEEM_INIT_PRIVATE_KEY.get_public_key()) ))
@@ -44,7 +44,7 @@
 
 #else // IS LIVE STEEM NETWORK
 
-#define STEEM_BLOCKCHAIN_VERSION              ( version(0, 22, 1) )
+#define STEEM_BLOCKCHAIN_VERSION              ( version(0, 23, 0) )
 
 #define STEEM_INIT_PUBLIC_KEY_STR             "STM8GC13uCZbP44HzMLV6zPZGwVQ8Nt4Kji8PapsPiNq1BK153XTX"
 #define STEEM_CHAIN_ID fc::sha256()
@@ -108,6 +108,7 @@
 #define STEEM_MAX_MEMO_SIZE                   2048
 #define STEEM_MAX_PROXY_RECURSION_DEPTH       4
 #define STEEM_VESTING_WITHDRAW_INTERVALS_PRE_HF_16 104
+#define STEEM_VESTING_WITHDRAW_INTERVALS_SPECIAL_CASE_HF_23 104
 #define STEEM_VESTING_WITHDRAW_INTERVALS      13
 #define STEEM_VESTING_WITHDRAW_INTERVAL_SECONDS (60*60*24*7) /// 1 week per interval
 #define STEEM_MAX_WITHDRAW_ROUTES             10


### PR DESCRIPTION
My proposal consists in two points:
1. **Steemit Inc accounts lose the possibility to vote** (for witnesses, proposals and posts). This will be applied not in a softfork but in a hardfork, meaning that all witnesses will have written this rule in their code.
2. **Power down of 2 years only for Steemit Inc accounts**. Concretely 1 payment per week during 104 periods. This rule will have effect during 2.5 years, and after that it changes to the normal rule of 3 months of power down.

**The community** will be sure that this stake will not be used to vote for witnesses and compromise the governance. And they will be confortable that the power down of this stake will take much more time (8 times a normal power down) to not affect a lot the price in a hypothetical dump.

**Justin Sun/Steemit Inc** will have freedom to manage his stake, but he cannot use these tokens to influence the governance, and the power down will take more time  (see that during the power down, each week he will less than 1% of the initial stake).

[**More details in this post**](http://steempeak.com/@jga/proposal-hf23-special-power-down-steemit-accounts)