### PR TITLE
Fix test_block_log

### DIFF
--- a/programs/util/test_block_log.cpp
+++ b/programs/util/test_block_log.cpp
@@ -1,6 +1,7 @@
 #include <steem/chain/database.hpp>
 #include <steem/protocol/block.hpp>
 #include <fc/io/raw.hpp>
+#include <fc/exception/exception.hpp>
 
 int main( int argc, char** argv, char** envp )
 {
@@ -37,22 +38,36 @@ int main( int argc, char** argv, char** envp )
       idump( (fc::raw::pack_size(b2)) );
 
       auto r1 = log.read_block( 0 );
+      FC_ASSERT( r1.first.id() == b1.id() );
       idump( (r1) );
       idump( (fc::raw::pack_size(r1.first)) );
 
       auto r2 = log.read_block( r1.second );
+      FC_ASSERT( r2.first.id() == b2.id() );
       idump( (r2) );
       idump( (fc::raw::pack_size(r2.first)) );
 
       idump( (log.read_head()) );
       idump( (fc::raw::pack_size(log.read_head())));
 
-      auto r3 = log.read_block( r2.second );
-      idump( (r3) );
+      // the following is expected to fail
+      // as EOF should be reached
+      bool threw = false;
+      try {
+         auto r3 = log.read_block(r2.second);
+         idump( (r3) );
+      }
+      catch (const fc::exception& e) {
+         threw = true;
+         edump((e.to_detail_string()));
+      }
+      FC_ASSERT(threw, "Expected EOF exception but none was thrown");
+      log.close();
    }
    catch ( const std::exception& e )
    {
       edump( ( std::string( e.what() ) ) );
+      return -1;
    }
 
    return 0;


### PR DESCRIPTION
Currently, the test_block_log will crash because of an intended failure:

```cpp
auto r3 = log.read_block( r2.second );
idump( (r3) );
```

Previously:
```cpp
auto r1 = log.read_block(0);       // ✅ OK, returns b1, next offset = 248
auto r2 = log.read_block(r1.second); // ✅ OK, returns b2, next offset = EOF
```

At this point, r2.second points to the end of the file, i.e., there’s no next block.

<img width="921" height="792" alt="image" src="https://github.com/user-attachments/assets/2b601ebf-dbca-4380-a651-5b722433127e" />

This is intended behaviour, but the error (exit) code is non-zero which is misleading. This PR addresses this issue and return 0 when tests pass.

## Tested
<img width="1302" height="1135" alt="image" src="https://github.com/user-attachments/assets/8b1373ee-b369-4661-8645-575262d21d5b" />

