### PR TITLE
Fixes and Refactor the Docker files

### DIFF
--- a/deploy/Dockerfile.azurelinux3.0
+++ b/deploy/Dockerfile.azurelinux3.0
@@ -13,6 +13,8 @@ ARG ENABLE_COVERAGE_TESTING=OFF
 ARG CHAINBASE_CHECK_LOCKING=OFF
 ARG UNIT_TEST=OFF
 ARG DOXYGEN=OFF
+ARG NUMBER_BUILD_THREADS
+RUN THREADS=$( [ -n "$NUMBER_BUILD_THREADS" ] && echo "$NUMBER_BUILD_THREADS" || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
 
 RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "STEEM_STATIC_BUILD: ${STEEM_STATIC_BUILD}" >> /etc/build_info && \
@@ -24,7 +26,8 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "ENABLE_COVERAGE_TESTING: ${ENABLE_COVERAGE_TESTING}" >> /etc/build_info && \
     echo "CHAINBASE_CHECK_LOCKING: ${CHAINBASE_CHECK_LOCKING}" >> /etc/build_info && \
     echo "UNIT_TEST: ${UNIT_TEST}" >> /etc/build_info && \
-    echo "DOXYGEN: ${DOXYGEN}"
+    echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
+    echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -118,7 +121,7 @@ RUN mkdir -p build && \
         ..
 
 RUN cd build && \
-    make -j3
+    make -j${THREADS}
     
 RUN cd build && \
     make install

--- a/deploy/Dockerfile.azurelinux3.0
+++ b/deploy/Dockerfile.azurelinux3.0
@@ -14,7 +14,6 @@ ARG CHAINBASE_CHECK_LOCKING=OFF
 ARG UNIT_TEST=OFF
 ARG DOXYGEN=OFF
 ARG NUMBER_BUILD_THREADS
-RUN THREADS=$( [ -n "$NUMBER_BUILD_THREADS" ] && echo "$NUMBER_BUILD_THREADS" || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
 
 RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "STEEM_STATIC_BUILD: ${STEEM_STATIC_BUILD}" >> /etc/build_info && \
@@ -29,7 +28,6 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
     echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
-ENV THREADS=${NUMBER_BUILD_THREADS}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN tdnf update -y && \
@@ -122,7 +120,9 @@ RUN mkdir -p build && \
         ..
 
 RUN cd build && \
-    make -j${THREADS}
+    make -j$( [ -n "$NUMBER_BUILD_THREADS" ] \
+        && echo "$NUMBER_BUILD_THREADS" \
+        || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
     
 RUN cd build && \
     make install

--- a/deploy/Dockerfile.azurelinux3.0
+++ b/deploy/Dockerfile.azurelinux3.0
@@ -29,6 +29,7 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
     echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
+ENV THREADS=${NUMBER_BUILD_THREADS}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN tdnf update -y && \

--- a/deploy/Dockerfile.azurelinux3.0
+++ b/deploy/Dockerfile.azurelinux3.0
@@ -169,4 +169,7 @@ RUN tdnf update -y && \
     tdnf autoremove -y && \
     tdnf clean all
 
+## make steemd available on $PATH
+ENV PATH="/usr/local/steemd/bin:${PATH}"
+
 CMD ["cat", "/etc/build_info"]

--- a/deploy/Dockerfile.debian13
+++ b/deploy/Dockerfile.debian13
@@ -138,4 +138,7 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists
 
+## make steemd available on $PATH
+ENV PATH="/usr/local/steemd/bin:${PATH}"
+    
 CMD ["cat", "/etc/build_info"]

--- a/deploy/Dockerfile.debian13
+++ b/deploy/Dockerfile.debian13
@@ -30,6 +30,7 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
     echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
+ENV THREADS=${NUMBER_BUILD_THREADS}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/deploy/Dockerfile.debian13
+++ b/deploy/Dockerfile.debian13
@@ -64,9 +64,7 @@ WORKDIR /usr/local/src
 ADD . /usr/local/src
 
 RUN pwd && \
-    git submodule update --init --recursive && \
-    cd libraries/fc/vendor/websocketpp && \
-    (git apply /usr/local/src/patches/websocketpp-patch-ini-asio.patch || echo "Patch already applied or failed") 
+    git submodule update --init --recursive
 
 RUN cd libraries/vendor/rocksdb && \
     (git apply /usr/local/src/patches/rocksdb-cmake.patch || echo "Patch already applied or cannot apply")

--- a/deploy/Dockerfile.debian13
+++ b/deploy/Dockerfile.debian13
@@ -15,7 +15,6 @@ ARG CHAINBASE_CHECK_LOCKING=OFF
 ARG UNIT_TEST=OFF
 ARG DOXYGEN=OFF
 ARG NUMBER_BUILD_THREADS
-RUN THREADS=$( [ -n "$NUMBER_BUILD_THREADS" ] && echo "$NUMBER_BUILD_THREADS" || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
 
 RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "STEEM_STATIC_BUILD: ${STEEM_STATIC_BUILD}" >> /etc/build_info && \
@@ -30,7 +29,6 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
     echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
-ENV THREADS=${NUMBER_BUILD_THREADS}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
@@ -89,7 +87,9 @@ RUN mkdir -p build && \
         ..
 
 RUN cd build && \
-    make -j${THREADS}
+    make -j$( [ -n "$NUMBER_BUILD_THREADS" ] \
+        && echo "$NUMBER_BUILD_THREADS" \
+        || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
     
 RUN cd build && \
     make install

--- a/deploy/Dockerfile.debian13
+++ b/deploy/Dockerfile.debian13
@@ -14,6 +14,8 @@ ARG ENABLE_COVERAGE_TESTING=OFF
 ARG CHAINBASE_CHECK_LOCKING=OFF
 ARG UNIT_TEST=OFF
 ARG DOXYGEN=OFF
+ARG NUMBER_BUILD_THREADS
+RUN THREADS=$( [ -n "$NUMBER_BUILD_THREADS" ] && echo "$NUMBER_BUILD_THREADS" || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
 
 RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "STEEM_STATIC_BUILD: ${STEEM_STATIC_BUILD}" >> /etc/build_info && \
@@ -25,7 +27,8 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "ENABLE_COVERAGE_TESTING: ${ENABLE_COVERAGE_TESTING}" >> /etc/build_info && \
     echo "CHAINBASE_CHECK_LOCKING: ${CHAINBASE_CHECK_LOCKING}" >> /etc/build_info && \
     echo "UNIT_TEST: ${UNIT_TEST}" >> /etc/build_info && \
-    echo "DOXYGEN: ${DOXYGEN}"
+    echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
+    echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -87,7 +90,7 @@ RUN mkdir -p build && \
         ..
 
 RUN cd build && \
-    make -j3
+    make -j${THREADS}
     
 RUN cd build && \
     make install

--- a/deploy/Dockerfile.ubuntu20.04
+++ b/deploy/Dockerfile.ubuntu20.04
@@ -13,6 +13,8 @@ ARG ENABLE_COVERAGE_TESTING=OFF
 ARG CHAINBASE_CHECK_LOCKING=OFF
 ARG UNIT_TEST=OFF
 ARG DOXYGEN=OFF
+ARG NUMBER_BUILD_THREADS
+RUN THREADS=$( [ -n "$NUMBER_BUILD_THREADS" ] && echo "$NUMBER_BUILD_THREADS" || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
 
 RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "STEEM_STATIC_BUILD: ${STEEM_STATIC_BUILD}" >> /etc/build_info && \
@@ -24,7 +26,8 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "ENABLE_COVERAGE_TESTING: ${ENABLE_COVERAGE_TESTING}" >> /etc/build_info && \
     echo "CHAINBASE_CHECK_LOCKING: ${CHAINBASE_CHECK_LOCKING}" >> /etc/build_info && \
     echo "UNIT_TEST: ${UNIT_TEST}" >> /etc/build_info && \
-    echo "DOXYGEN: ${DOXYGEN}"
+    echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
+    echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -96,7 +99,7 @@ RUN mkdir -p build && \
         ..
 
 RUN cd build && \
-    make -j2
+    make -j${THREADS}
     
 RUN cd build && \
     make install

--- a/deploy/Dockerfile.ubuntu20.04
+++ b/deploy/Dockerfile.ubuntu20.04
@@ -14,7 +14,6 @@ ARG CHAINBASE_CHECK_LOCKING=OFF
 ARG UNIT_TEST=OFF
 ARG DOXYGEN=OFF
 ARG NUMBER_BUILD_THREADS
-RUN THREADS=$( [ -n "$NUMBER_BUILD_THREADS" ] && echo "$NUMBER_BUILD_THREADS" || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
 
 RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "STEEM_STATIC_BUILD: ${STEEM_STATIC_BUILD}" >> /etc/build_info && \
@@ -29,7 +28,6 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
     echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
-ENV THREADS=${NUMBER_BUILD_THREADS}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
@@ -100,7 +98,9 @@ RUN mkdir -p build && \
         ..
 
 RUN cd build && \
-    make -j${THREADS}
+    make -j$( [ -n "$NUMBER_BUILD_THREADS" ] \
+        && echo "$NUMBER_BUILD_THREADS" \
+        || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
     
 RUN cd build && \
     make install

--- a/deploy/Dockerfile.ubuntu20.04
+++ b/deploy/Dockerfile.ubuntu20.04
@@ -29,6 +29,7 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
     echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
+ENV THREADS=${NUMBER_BUILD_THREADS}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/deploy/Dockerfile.ubuntu20.04
+++ b/deploy/Dockerfile.ubuntu20.04
@@ -58,12 +58,19 @@ RUN ln -s /usr/bin/make /usr/bin/gmake
 
 ## default version at ubuntu20.04 is boost 1.71
 ## upgrade to boost 1.78
-RUN wget https://archives.boost.io/release/1.78.0/source/boost_1_78_0.tar.gz && \
-    tar -xvzf boost_1_78_0.tar.gz && \
-    cd boost_1_78_0 && \
-    ./bootstrap.sh && \
-    ./b2 && \
-    ./b2 install
+## Build Boost 1.78 (required by Steem)
+RUN set -e && \
+    BOOST_VERSION_DOT=1.78.0 && \
+    BOOST_VERSION_UNDERSCORE=1_78_0 && \
+    BOOST_URL="https://archives.boost.io/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz" && \
+    BOOST_SHA256="94ced8b72956591c4775ae2207a9763d3600b30d9d7446562c552f0a14a63be7" && \
+    wget -q "${BOOST_URL}" -O boost_${BOOST_VERSION_UNDERSCORE}.tar.gz && \
+    echo "${BOOST_SHA256}  boost_${BOOST_VERSION_UNDERSCORE}.tar.gz" | sha256sum -c - && \
+    tar -xvzf boost_${BOOST_VERSION_UNDERSCORE}.tar.gz && \
+    cd boost_${BOOST_VERSION_UNDERSCORE} && \
+    ./bootstrap.sh --prefix=/usr/local --with-toolset=gcc || { cat bootstrap.log; exit 1; } && \
+    ./b2 -j"$(nproc)" toolset=gcc install || { cat bootstrap.log; exit 1; } && \
+    cd .. && rm -rf boost_${BOOST_VERSION_UNDERSCORE} boost_${BOOST_VERSION_UNDERSCORE}.tar.gz
 
 WORKDIR /usr/local/src
 ADD . /usr/local/src
@@ -139,5 +146,8 @@ RUN apt-get update && \
     apt-get install -y libsnappy-dev libreadline-dev && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists
+
+## make steemd available on $PATH
+ENV PATH="/usr/local/steemd/bin:${PATH}"
 
 CMD ["cat", "/etc/build_info"]

--- a/deploy/Dockerfile.ubuntu22.04
+++ b/deploy/Dockerfile.ubuntu22.04
@@ -14,7 +14,6 @@ ARG CHAINBASE_CHECK_LOCKING=OFF
 ARG UNIT_TEST=OFF
 ARG DOXYGEN=OFF
 ARG NUMBER_BUILD_THREADS
-RUN THREADS=$( [ -n "$NUMBER_BUILD_THREADS" ] && echo "$NUMBER_BUILD_THREADS" || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
 
 RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "STEEM_STATIC_BUILD: ${STEEM_STATIC_BUILD}" >> /etc/build_info && \
@@ -29,7 +28,6 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
     echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
-ENV THREADS=${NUMBER_BUILD_THREADS}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
@@ -98,7 +96,9 @@ RUN mkdir -p build && \
         ..
 
 RUN cd build && \
-    make -j${THREADS}
+    make -j$( [ -n "$NUMBER_BUILD_THREADS" ] \
+        && echo "$NUMBER_BUILD_THREADS" \
+        || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
     
 RUN cd build && \
     make install

--- a/deploy/Dockerfile.ubuntu22.04
+++ b/deploy/Dockerfile.ubuntu22.04
@@ -56,12 +56,19 @@ RUN apt-get update && \
 
 ## default version at ubuntu22.04 is boost 1.74
 ## upgrade to boost 1.78
-RUN wget https://archives.boost.io/release/1.78.0/source/boost_1_78_0.tar.gz && \
-    tar -xvzf boost_1_78_0.tar.gz && \
-    cd boost_1_78_0 && \
-    ./bootstrap.sh && \
-    ./b2 && \
-    ./b2 install
+## Build Boost 1.78 (required by Steem)
+RUN set -e && \
+    BOOST_VERSION_DOT=1.78.0 && \
+    BOOST_VERSION_UNDERSCORE=1_78_0 && \
+    BOOST_URL="https://archives.boost.io/release/${BOOST_VERSION_DOT}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz" && \
+    BOOST_SHA256="94ced8b72956591c4775ae2207a9763d3600b30d9d7446562c552f0a14a63be7" && \
+    wget -q "${BOOST_URL}" -O boost_${BOOST_VERSION_UNDERSCORE}.tar.gz && \
+    echo "${BOOST_SHA256}  boost_${BOOST_VERSION_UNDERSCORE}.tar.gz" | sha256sum -c - && \
+    tar -xvzf boost_${BOOST_VERSION_UNDERSCORE}.tar.gz && \
+    cd boost_${BOOST_VERSION_UNDERSCORE} && \
+    ./bootstrap.sh --prefix=/usr/local --with-toolset=gcc || { cat bootstrap.log; exit 1; } && \
+    ./b2 -j"$(nproc)" toolset=gcc install || { cat bootstrap.log; exit 1; } && \
+    cd .. && rm -rf boost_${BOOST_VERSION_UNDERSCORE} boost_${BOOST_VERSION_UNDERSCORE}.tar.gz
 
 WORKDIR /usr/local/src
 ADD . /usr/local/src
@@ -137,5 +144,8 @@ RUN apt-get update && \
     apt-get install -y libsnappy-dev libreadline-dev && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists
+
+## make steemd available on $PATH
+ENV PATH="/usr/local/steemd/bin:${PATH}"
 
 CMD ["cat", "/etc/build_info"]

--- a/deploy/Dockerfile.ubuntu22.04
+++ b/deploy/Dockerfile.ubuntu22.04
@@ -13,6 +13,8 @@ ARG ENABLE_COVERAGE_TESTING=OFF
 ARG CHAINBASE_CHECK_LOCKING=OFF
 ARG UNIT_TEST=OFF
 ARG DOXYGEN=OFF
+ARG NUMBER_BUILD_THREADS
+RUN THREADS=$( [ -n "$NUMBER_BUILD_THREADS" ] && echo "$NUMBER_BUILD_THREADS" || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
 
 RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "STEEM_STATIC_BUILD: ${STEEM_STATIC_BUILD}" >> /etc/build_info && \
@@ -24,7 +26,8 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "ENABLE_COVERAGE_TESTING: ${ENABLE_COVERAGE_TESTING}" >> /etc/build_info && \
     echo "CHAINBASE_CHECK_LOCKING: ${CHAINBASE_CHECK_LOCKING}" >> /etc/build_info && \
     echo "UNIT_TEST: ${UNIT_TEST}" >> /etc/build_info && \
-    echo "DOXYGEN: ${DOXYGEN}"
+    echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
+    echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -94,7 +97,7 @@ RUN mkdir -p build && \
         ..
 
 RUN cd build && \
-    make -j2
+    make -j${THREADS}
     
 RUN cd build && \
     make install

--- a/deploy/Dockerfile.ubuntu22.04
+++ b/deploy/Dockerfile.ubuntu22.04
@@ -29,6 +29,7 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
     echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
+ENV THREADS=${NUMBER_BUILD_THREADS}
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/deploy/Dockerfile.ubuntu24.04
+++ b/deploy/Dockerfile.ubuntu24.04
@@ -134,4 +134,7 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists
 
+## make steemd available on $PATH
+ENV PATH="/usr/local/steemd/bin:${PATH}"
+
 CMD ["cat", "/etc/build_info"]

--- a/deploy/Dockerfile.ubuntu24.04
+++ b/deploy/Dockerfile.ubuntu24.04
@@ -13,6 +13,8 @@ ARG ENABLE_COVERAGE_TESTING=OFF
 ARG CHAINBASE_CHECK_LOCKING=OFF
 ARG UNIT_TEST=OFF
 ARG DOXYGEN=OFF
+ARG NUMBER_BUILD_THREADS
+RUN THREADS=$( [ -n "$NUMBER_BUILD_THREADS" ] && echo "$NUMBER_BUILD_THREADS" || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
 
 RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "STEEM_STATIC_BUILD: ${STEEM_STATIC_BUILD}" >> /etc/build_info && \
@@ -24,7 +26,8 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "ENABLE_COVERAGE_TESTING: ${ENABLE_COVERAGE_TESTING}" >> /etc/build_info && \
     echo "CHAINBASE_CHECK_LOCKING: ${CHAINBASE_CHECK_LOCKING}" >> /etc/build_info && \
     echo "UNIT_TEST: ${UNIT_TEST}" >> /etc/build_info && \
-    echo "DOXYGEN: ${DOXYGEN}"
+    echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
+    echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -83,7 +86,7 @@ RUN mkdir -p build && \
         ..
 
 RUN cd build && \
-    make -j3
+    make -j${THREADS}
     
 RUN cd build && \
     make install

--- a/deploy/Dockerfile.ubuntu24.04
+++ b/deploy/Dockerfile.ubuntu24.04
@@ -14,7 +14,6 @@ ARG CHAINBASE_CHECK_LOCKING=OFF
 ARG UNIT_TEST=OFF
 ARG DOXYGEN=OFF
 ARG NUMBER_BUILD_THREADS
-RUN THREADS=$( [ -n "$NUMBER_BUILD_THREADS" ] && echo "$NUMBER_BUILD_THREADS" || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
 
 RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "STEEM_STATIC_BUILD: ${STEEM_STATIC_BUILD}" >> /etc/build_info && \
@@ -28,8 +27,6 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "UNIT_TEST: ${UNIT_TEST}" >> /etc/build_info && \
     echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
     echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
-
-ENV THREADS=${NUMBER_BUILD_THREADS}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -90,7 +87,9 @@ RUN mkdir -p build && \
         ..
 
 RUN cd build && \
-    make -j${THREADS}
+    make -j$( [ -n "$NUMBER_BUILD_THREADS" ] \
+        && echo "$NUMBER_BUILD_THREADS" \
+        || echo $(( $(nproc) > 1 ? $(nproc) - 1 : 1 )) )
     
 RUN cd build && \
     make install

--- a/deploy/Dockerfile.ubuntu24.04
+++ b/deploy/Dockerfile.ubuntu24.04
@@ -29,6 +29,8 @@ RUN echo "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}" >> /etc/build_info && \
     echo "DOXYGEN: ${DOXYGEN}" >> /etc/build_info && \
     echo "NUMBER_BUILD_THREADS: ${THREADS}" >> /etc/build_info
 
+ENV THREADS=${NUMBER_BUILD_THREADS}
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
@@ -57,7 +59,8 @@ RUN apt-get update && \
         libbz2-dev \
         liblz4-dev \
         libzstd-dev \
-        wget
+        wget \
+        librocksdb-dev
 
 WORKDIR /usr/local/src
 ADD . /usr/local/src
@@ -74,6 +77,7 @@ RUN mkdir -p build && \
     cd build && \
     cmake \
         -DCMAKE_INSTALL_PREFIX=/usr/local/steemd \
+        -DUSE_VENDORED_ROCKSDB=OFF \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
         -DLOW_MEMORY_NODE=${LOW_MEMORY_MODE} \
         -DCLEAR_VOTES=${CLEAR_VOTES} \

--- a/doc/building.md
+++ b/doc/building.md
@@ -16,6 +16,10 @@ The minimal Boost version required is [1.78](https://www.boost.org/releases/1.78
 
 ## Compile-Time Options (cmake)
 
+### NUMBER_BUILD_THREADS
+
+This specifies the number of threads to build steemd e.g. `make -j${NUMBER_BUILD_THREADS}`. By default it is equal to `$(nproc)-1`
+
 ### CMAKE_BUILD_TYPE=[Release/Debug]
 
 Specifies whether to build with or without optimization and without or with


### PR DESCRIPTION
This is the seventh PR of the DAO Project [Proposal: Fixing Steemd Build Dependencies in the Latest OS](https://steemit.com/sps/@justyy/proposal-fixing-steemd-build-dependencies-in-the-latest-os). 

Previous PRs: 
- #3704 (Fix test_block_log)
- #3703 (Debian13)
- #3702 (AzureLinux3)
- #3701 (Ubuntu24.04)
- #3700 (Ubuntu22.04)
- #3699 (Ubuntu20.04 - cleanup - submodule fixes etc)

This PR refactors and fixes the Docker files:
1. Checks SHA256 of Boost 1.78 to avoid supply-chain attacks
2. Supports `--build-arg NUMBER_BUILD_THREADS` to specify the number of threads e.g. `make -j${NUMBER_BUILD_THREADS}`
3. Sets PATH for finding `steemd`
4. Use system-installed RocksDB on Ubuntu 24.04 (`-DUSE_VENDORED_ROCKSDB=OFF`) for faster, more reliable builds e.g. with `librocksdb-dev` installed.
5. Fixes the Debian build by removing the wrong patch.


As usual, steemd has been built, tested and uploaded to docker hub: https://hub.docker.com/r/justyy/steem/tags
```bash
docker pull justyy/steem:debian13
docker pull justyy/steem:azurelinux3
docker pull justyy/steem:ubuntu24.04
docker pull justyy/steem:ubuntu22.04
docker pull justyy/steem:ubuntu20.04
```