### PR TITLE
Add Basic Github CI to Build All Dockerfiles

### DIFF
--- a/.github/workflows/build-steemd.yml
+++ b/.github/workflows/build-steemd.yml
@@ -1,0 +1,46 @@
+name: Build All steemd Dockerfiles
+
+on:
+  push:
+    paths:
+      - "deploy/**"
+      - ".github/workflows/build-steemd.yml"
+
+  pull_request:
+
+  workflow_dispatch:
+
+jobs:
+  build-matrix:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile:
+          - Dockerfile.azurelinux3.0
+          - Dockerfile.debian13
+          - Dockerfile.ubuntu20.04
+          - Dockerfile.ubuntu22.04
+          - Dockerfile.ubuntu24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          set -ex
+
+          FILE="deploy/${{ matrix.dockerfile }}"
+          NAME="${{ matrix.dockerfile }}"
+          TAG="steem:${NAME#Dockerfile.}"
+
+          echo "Building Dockerfile: $FILE"
+          echo "Tag: $TAG"
+
+          sudo -E docker build \
+            --build-arg NUMBER_BUILD_THREADS=1 \
+            -t "$TAG" \
+            -f "$FILE" \
+            .


### PR DESCRIPTION
This is the eighth PR of the DAO Project [Proposal: Fixing Steemd Build Dependencies in the Latest OS](https://steemit.com/sps/@justyy/proposal-fixing-steemd-build-dependencies-in-the-latest-os). 

Previous PRs: 
- #3705 (Refactor/Fixes)
- #3704 (Fix test_block_log)
- #3703 (Debian13)
- #3702 (AzureLinux3)
- #3701 (Ubuntu24.04)
- #3700 (Ubuntu22.04)
- #3699 (Ubuntu20.04 - cleanup - submodule fixes etc)

## CI Build
This PR builds steemd in all OS variants listed in the `deploy` folder. Using 1 thread to minimize memory usage. This PR ensures a minimal check for the future PRs. 

Please note: the tests are not run yet. I'll have another PR to run some basic tests.

<img width="329" height="364" alt="image" src="https://github.com/user-attachments/assets/e7fc29ad-94ee-4c24-bf77-610f1fdc3305" />

