### PR TITLE
fix(p2p): downgrade unlinkable block error to warning during sync

### DIFF
--- a/libraries/plugins/p2p/p2p_plugin.cpp
+++ b/libraries/plugins/p2p/p2p_plugin.cpp
@@ -214,7 +214,17 @@ bool p2p_plugin_impl::handle_block( const graphene::net::block_message& blk_msg,
 
          return result;
       } catch ( const chain::unlinkable_block_exception& e ) {
-         // translate to a graphene::net exception
+         // During sync, receiving blocks from forks is expected behavior.
+         // Downgrade to warning to avoid log noise.
+         if ( sync_mode ) {
+            fc_wlog(fc::logger::get("sync"),
+                  "Dropping unlinkable sync block #${block_num} (head is ${head}): ${e}",
+                  ("block_num", blk_msg.block.block_num())
+                  ("head", head_block_num)
+                  ("e", e.to_detail_string()));
+            return false;
+         }
+         // Non-sync: translate to a graphene::net exception to trigger sync restart
          fc_elog(fc::logger::get("sync"),
                "Error when pushing block, current head block is ${head}:\n${e}",
                ("e", e.to_detail_string())


### PR DESCRIPTION
During blockchain synchronization, receiving blocks from forks is expected behavior as multiple peers may be on different forks. Previously, these were logged as errors via elog(), causing log noise and false alerts.

This change:
- Checks sync_mode in the unlinkable_block_exception handler
- Uses fc_wlog (warning level) for sync mode instead of elog (error level)
- Returns false immediately in sync mode, avoiding unnecessary exception propagation to node.cpp
- Preserves existing error behavior for non-sync mode (triggers sync restart)

Fixes: Error when pushing block elog noise during sync
Reference: i-05d97adb280d9914e (steemit-production-steemd-002)